### PR TITLE
[COOK-2528] runit isn't necessary

### DIFF
--- a/recipes/node_ssh.rb
+++ b/recipes/node_ssh.rb
@@ -21,7 +21,6 @@
 #
 
 include_recipe "java"
-include_recipe "runit"
 
 unless Chef::Config[:solo]
   unless node['jenkins']['server']['pubkey']


### PR DESCRIPTION
Unless I'm wrong, node_ssh doesn't need runit.
