### PR TITLE
Moved jvm_options before -jar

### DIFF
--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -4,6 +4,6 @@ touch jenkins.start
 exec chpst -u <%= node['jenkins']['server']['user'] %> -U <%= node['jenkins']['server']['user'] %> \
   env HOME=<%= node['jenkins']['server']['home'] %> \
   JENKINS_HOME=<%= node['jenkins']['server']['home'] %>/jenkins-data \
-  java -jar jenkins.war \
-  -Xloggc:<%= node['jenkins']['server']['log_dir'] %>/gclog.log <%= node['jenkins']['server']['jvm_options'] %>
+  java <%= node['jenkins']['server']['jvm_options'] %> -jar jenkins.war \
+  -Xloggc:<%= node['jenkins']['server']['log_dir'] %>/gclog.log 
 


### PR DESCRIPTION
As of Jenkins 1.4+, it validates command line arguments.  Putting JVM options after the -jar, such as "-Dorg.jenkinsci.plugins.gitclient.Git.useCLI=true" results in the error "Caused by: java.lang.IllegalArgumentException: Multiple command line argument specified: -Dorg.jenkinsci.plugins.gitclient.Git.useCLI=true" as Jenkins believes you are passing it the argument.  Moving the jvm_options before the -jar solves this.
