### PR TITLE
[COOK-2654] Basic authentication isn't supported in the proxy_nginx recipe

### DIFF
--- a/recipes/proxy_nginx.rb
+++ b/recipes/proxy_nginx.rb
@@ -29,6 +29,14 @@ end
 
 host_name = node['jenkins']['http_proxy']['host_name'] || node['fqdn']
 
+template "#{node['nginx']['dir']}/htpasswd" do
+  variables( :username => node['jenkins']['http_proxy']['basic_auth_username'],
+             :password => node['jenkins']['http_proxy']['basic_auth_password'])
+  owner node['nginx']['user']
+  group node['nginx']['user']
+  mode '0600'
+end
+
 template "#{node['nginx']['dir']}/sites-available/jenkins.conf" do
   source      "nginx_jenkins.conf.erb"
   owner       'root'

--- a/templates/default/nginx_jenkins.conf.erb
+++ b/templates/default/nginx_jenkins.conf.erb
@@ -26,6 +26,12 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
+
+<% case node['jenkins']['http_proxy']['server_auth_method'] -%>
+<% when 'basic' -%>
+    auth_basic            "Restricted";
+    auth_basic_user_file  htpasswd;
+<% end -%>
   }
 
   error_log         <%= node[:nginx][:log_dir] %>/jenkins-error.log;


### PR DESCRIPTION
I've added support for basic authentication in the proxy_nginx recipe. It's virtually identical to the implementation in the proxy_apache recipe.
