### PR TITLE
fix namespace to work with current ssh-slaves plugin

### DIFF
--- a/libraries/manage_node.rb
+++ b/libraries/manage_node.rb
@@ -121,7 +121,7 @@ props = []
 
 def new_ssh_launcher(args) {
   Jenkins.instance.pluginManager.getPlugin("ssh-slaves").classLoader.
-    loadClass("jenkins.plugins.sshslaves.SSHLauncher").
+    loadClass("hudson.plugins.sshslaves.SSHLauncher").
       getConstructor([String, int, String, String, String, String] as Class[]).newInstance(args)
 }
 


### PR DESCRIPTION
Needed this additional change to get jenkins::node_ssh working. 
