### PR TITLE
for [COOK-2684] - added check for HTTPForbidden when restarting jenkins ...

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -37,7 +37,8 @@ module JenkinsHelper
   def self.endpoint_responding?(url)
     response = Chef::REST::RESTRequest.new(:GET, url, nil).call
     if response.kind_of?(Net::HTTPSuccess) ||
-          response.kind_of?(Net::HTTPRedirection)
+          response.kind_of?(Net::HTTPRedirection) ||
+          response.kind_of?(Net::HTTPForbidden)
       Chef::Log.debug("GET to #{url} successful")
       return true
     else


### PR DESCRIPTION
... in case private auth is being used, this prevents endless loop
