### PR TITLE
endpoint_responding? should return true on Net::HTTPForbidden

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -37,7 +37,8 @@ module JenkinsHelper
   def self.endpoint_responding?(url)
     response = Chef::REST::RESTRequest.new(:GET, url, nil).call
     if response.kind_of?(Net::HTTPSuccess) ||
-          response.kind_of?(Net::HTTPRedirection)
+          response.kind_of?(Net::HTTPRedirection) ||
+          response.kind_of?(Net::HTTPForbidden)
       Chef::Log.debug("GET to #{url} successful")
       return true
     else


### PR DESCRIPTION
Between installing Jenkins using this cookbook, and my Chef run finishing, I setup a fully functioning configuration, including authentication, correct users and jobs.

Due to the delayed restart in this cookbook, and the `JenkinsHelper` which is used for this restart, my chef script never finishes.

This is due to this code:

``` ruby
    response = Chef::REST::RESTRequest.new(:GET, url, nil).call
    if response.kind_of?(Net::HTTPSuccess) ||
          response.kind_of?(Net::HTTPRedirection)
      Chef::Log.debug("GET to #{url} successful")
      return true
    else
      Chef::Log.debug("GET to #{url} returned #{response.code} / #{response.class}")
      return false
    end
```

I propose this change:

``` diff
    if response.kind_of?(Net::HTTPSuccess) ||
-          response.kind_of?(Net::HTTPRedirection)
+          response.kind_of?(Net::HTTPRedirection) ||
+          response.kind_of?(Net::HTTPForbidden)
```

this allows for the restart to finish, even when the api endpoint can't be reached because of authentication.

Another way would be to actually implement proper authentication inside the restart script, but I feel like this is overkill, as the `HTTPForbidden` already indicates _something_ is listening on that endpoint and rejecting the request. It's basically the same as `HTTPSuccess` where we accept that _something_ is listening, without knowing that it's actually Jenkins.
