### PR TITLE
[COOK-2754] Do not include nginx::source directly, include nginx::default

### DIFF
--- a/recipes/proxy_nginx.rb
+++ b/recipes/proxy_nginx.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_recipe "nginx::source"
+include_recipe "nginx"
 
 if node['jenkins']['http_proxy']['www_redirect'] == "enable"
   www_redirect = true


### PR DESCRIPTION
In jenkins, no reasons to require nginx built from source.
Then, in jenkins::proxy_nginx include nginx::default.
