### PR TITLE
COOK-2774: Fix freeze when Jenkins is stopped

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -102,7 +102,9 @@ log "plugins updated, restarting jenkins" do
   notifies :restart, "runit_service[jenkins]"
 end
 
-runit_service "jenkins" do
-  action [:enable, :start]
+runit_service "jenkins"
+
+log "start jenkins" do
+  notifies :start, "runit_service[jenkins]", :immediately
   notifies :create, "ruby_block[block_until_operational]", :immediately
 end


### PR DESCRIPTION
Chef executes notifications after each resource action, not after all
resource actions are completed.  Previously, if Jenkins was stopped,
these events would occur:
- runit_service[jenkins] :enable action
- notify block_until_operational resource
- runit_service[jenkins] :start action

Because Jenkins was not already running when the
"block_until_operational" resource was executed, Chef would block
forever.

This attempts to fix this by using a separate resource to notify
block_until_operational only after Jenkins is started.

[Fixes [#CHEF-2774](http://tickets.opscode.com/browse/COOK-2774)]
