### PR TITLE
Accounts for Jenkins API returning 403

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -37,7 +37,7 @@ module JenkinsHelper
   def self.endpoint_responding?(url)
     response = Chef::REST::RESTRequest.new(:GET, url, nil).call
     if response.kind_of?(Net::HTTPSuccess) ||
-          response.kind_of?(Net::HTTPForbidden ||
+          response.kind_of?(Net::HTTPForbidden) ||
           response.kind_of?(Net::HTTPRedirection)
       Chef::Log.debug("GET to #{url} successful")
       return true


### PR DESCRIPTION
For installations of Jenkins where login is required a 403 response is returned from the Jenkins API when requesting http://your-jenkins-server.com/api/json. Currently, the `jenkins::server` recipe checks that API URL and blocks the chef run from progressing until a 200 or 302 are returned. This change allows the `jenkins::server` recipe to continue running if the Jenkins API returns a 403, which is a valid response.
