### PR TITLE
[COOK-3353] Fix ProxyPassReverse for SSL enabled Apache

### DIFF
--- a/templates/default/_apache_common.erb
+++ b/templates/default/_apache_common.erb
@@ -16,6 +16,7 @@
   ProxyPreserveHost on
   ProxyPass         /  http://localhost:<%= @jenkins_port %>/
   ProxyPassReverse  /  http://localhost:<%= @jenkins_port %>/
+  ProxyPassReverse  /  http://<%= @host_name %>/
 <% @host_aliases.each do |a| -%>
   ProxyPassReverse  /  http://<%= a%>
 <% end -%>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3353

Add an additional ProxyPassReverse directive to redirect non-SSL URLs generated by Jenkins to the SSL side.  Without this entry, Jenkins complains about an invalid proxy configuration.

Documentation available @ https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache
