### PR TITLE
Include environment configurations to node_jnlp

### DIFF
--- a/recipes/node_jnlp.rb
+++ b/recipes/node_jnlp.rb
@@ -47,8 +47,8 @@ jenkins_node node['jenkins']['node']['name'] do
   labels       node['jenkins']['node']['labels']
   mode         node['jenkins']['node']['mode']
   launcher     "jnlp"
-  mode         node['jenkins']['node']['mode']
   availability node['jenkins']['node']['availability']
+  env          node['jenkins']['node']['env']
 end
 
 remote_file slave_jar do


### PR DESCRIPTION
Currently, jenkins::node_jnlp ignores node['jenkins']['node']['env']
