### PR TITLE
[COOK-3755] Only run "ensure jenkins is running" if jenkins actually isn't running

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -118,4 +118,8 @@ runit_service "jenkins"
 log "ensure jenkins is running" do
   notifies :start, "runit_service[jenkins]", :immediately
   notifies :create, "ruby_block[block_until_operational]", :immediately
+  not_if {
+      test_url = URI.parse("#{node['jenkins']['server']['url']}/api/json")
+      JenkinsHelper.endpoint_responding?(test_url)
+  }
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3755
