### PR TITLE
add secret to jenkins slaves that use jnlp

### DIFF
--- a/files/default/node_info.groovy
+++ b/files/default/node_info.groovy
@@ -70,6 +70,9 @@ else {
   }
   else if (launcher instanceof JNLPLauncher) {
     node["launcher"] = "jnlp"
+    if (jenkins.slaves.JnlpSlaveAgentProtocol.declaredFields.find { it.name == 'SLAVE_SECRET' }) {
+      node["secret"] = jenkins.slaves.JnlpSlaveAgentProtocol.SLAVE_SECRET.mac( slave.name )
+    }
   }
   else {
     node["launcher"] = "ssh"

--- a/recipes/node_jnlp.rb
+++ b/recipes/node_jnlp.rb
@@ -60,6 +60,16 @@ remote_file slave_jar do
   end
 end
 
+secret = ''
+jenkins_cli "node_info for #{node[:jenkins][:node][:name]} to get jnlp secret" do
+  command "groovy node_info.groovy #{node[:jenkins][:node][:name]}"
+  block do |stdout|
+    current_node = JSON.parse( stdout )
+    secret.replace current_node['secret'] if current_node['secret']
+  end
+end
+
 runit_service service_name do
   action :enable
+  options(:secret => secret)
 end

--- a/recipes/node_windows.rb
+++ b/recipes/node_windows.rb
@@ -40,22 +40,6 @@ env "JENKINS_URL" do
   value server_url
 end
 
-template "#{home}/jenkins-slave.xml" do
-  source "jenkins-slave.xml.erb"
-  variables(:jenkins_home => home,
-            :jnlp_url => "#{server_url}/computer/#{node['jenkins']['node']['name']}/slave-agent.jnlp")
-end
-
-remote_file jenkins_exe do
-  source "http://maven.dyndns.org/2/com/sun/winsw/winsw/1.8/winsw-1.8-bin.exe"
-  not_if { File.exists?(jenkins_exe) }
-end
-
-execute "#{jenkins_exe} install" do
-  cwd home
-  only_if { WMI::Win32_Service.find(:first, :conditions => {:name => service_name}).nil? }
-end
-
 jenkins_node node['jenkins']['node']['name'] do
   description  node['jenkins']['node']['description']
   executors    node['jenkins']['node']['executors']
@@ -70,6 +54,37 @@ end
 remote_file "#{home_dir}\\slave.jar" do
   source "#{server_url}/jnlpJars/slave.jar"
   notifies :restart, "service[#{service_name}]", :immediately
+end
+
+cookbook_file "#{node[:jenkins][:node][:home]}/node_info.groovy" do
+  source "node_info.groovy"
+end
+
+secret = ''
+jenkins_cli "node_info for #{node[:jenkins][:node][:name]} to get jnlp secret" do
+  command "groovy node_info.groovy #{node[:jenkins][:node][:name]}"
+  block do |stdout|
+    current_node = JSON.parse( stdout )
+    secret.replace current_node['secret'] if current_node['secret']
+  end
+end
+
+template "#{home}/jenkins-slave.xml" do
+  source "jenkins-slave.xml.erb"
+  variables(:jenkins_home => home,
+            :jnlp_url => "#{server_url}/computer/#{node['jenkins']['node']['name']}/slave-agent.jnlp",
+            :jnlp_secret => secret)
+  notifies :restart, "service[#{service_name}]"
+end
+
+remote_file jenkins_exe do
+  source "http://maven.dyndns.org/2/com/sun/winsw/winsw/1.8/winsw-1.8-bin.exe"
+  not_if { File.exists?(jenkins_exe) }
+end
+
+execute "#{jenkins_exe} install" do
+  cwd home
+  only_if { WMI::Win32_Service.find(:first, :conditions => {:name => service_name}).nil? }
 end
 
 service service_name do

--- a/templates/default/jenkins-slave.xml.erb
+++ b/templates/default/jenkins-slave.xml.erb
@@ -39,7 +39,7 @@ THE SOFTWARE.
     The following value assumes that you have java in your PATH.
   -->
   <executable>java</executable>
-  <arguments>-Xrs -jar "<%= @jenkins_home %>\slave.jar" -jnlpUrl <%= @jnlp_url %></arguments>
+  <arguments>-Xrs -jar "<%= @jenkins_home %>\slave.jar" -jnlpUrl <%= @jnlp_url %> <%= !@jnlp_secret || @jnlp_secret.empty? ? '' : "-secret #{@jnlp_secret}" %></arguments>
   <!--
     interactive flag causes the empty black Java window to be displayed.
     I'm still debugging this.

--- a/templates/default/sv-jenkins-slave-run.erb
+++ b/templates/default/sv-jenkins-slave-run.erb
@@ -4,4 +4,5 @@ cd <%= node['jenkins']['node']['home'] %>
 exec chpst -u <%= node['jenkins']['node']['user'] %> \
   java -jar <%= node['jenkins']['node']['home'] %>/slave.jar \
   -jnlpUrl <%= node['jenkins']['server']['url'] %>/computer/<%= node['jenkins']['node']['name'] %>/slave-agent.jnlp \
+  <%= !@options[:secret] || @options[:secret].empty? ? '' : "-secret #{@options[:secret]}" %> \
   <%= node['jenkins']['node']['jvm_options'] %>


### PR DESCRIPTION
I don't have any tests for this but test-kitchen and kitchen-vagrant currently do not support multi-VM tests so I'm not sure how to test having a jenkins master and a jenkins jnlp or windows slave connected to the master.

I've tested these recipes on our internal chef server and jenkins nodes and they work there (FWIW).
