### PR TITLE
Added support for Net::HTTPOK status on service check helper

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -37,6 +37,7 @@ module JenkinsHelper
   def self.endpoint_responding?(url)
     response = Chef::REST::RESTRequest.new(:GET, url, nil).call
     if response.kind_of?(Net::HTTPSuccess) ||
+          response.kind_of?(Net::HTTPOK) ||
           response.kind_of?(Net::HTTPRedirection) ||
           response.kind_of?(Net::HTTPForbidden)
       Chef::Log.debug("GET to #{url} successful")


### PR DESCRIPTION
On newer Chef clients (currently tested on 11.4.4), Chef::REST::RESTRequest.new(:GET, url, nil).call returns Net::HTTPOK on success, which does not fall under the cases tested in the conditional. This PR addresses that.
