### PR TITLE
[COOK-3534][COOK-3535] Add virtualization system to default tags and fix...

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -148,3 +148,12 @@ suites:
         server_auth_method: basic
         basic_auth_username: foo
         basic_auth_password: bar
+- name: node
+  run_list:
+  - recipe[jenkins::server]
+  - recipe[jenkins::node]
+  attributes:
+    jenkins:
+      node:
+        env:
+          foo: bar

--- a/libraries/manage_node.rb
+++ b/libraries/manage_node.rb
@@ -80,7 +80,7 @@ def jenkins_node_manage(args)
 
   if args[:env]
     map = args[:env].collect { |k,v| %Q("#{k}":"#{v}") }.join(",")
-    env = "new jenkins.EnvVars([#{map}])"
+    env = "new hudson.EnvVars([#{map}])"
   else
     env = "null"
   end

--- a/providers/node.rb
+++ b/providers/node.rb
@@ -99,5 +99,6 @@ def platform_labels
   platform_labels << node['kernel']['machine'] # x86_64
   platform_labels << node['os'] # linux
   platform_labels << node['os_version'] # 2.6.32-38-server
+  platform_labels << node['virtualization']['system'] # xen
   platform_labels
 end


### PR DESCRIPTION
... EnvVars

Also add a kitchen scenario for a node to test setting these fixes.

Note that the EnvVars fix is also from [PR 47](https://github.com/opscode-cookbooks/jenkins/pull/47). Minitests may be added once [PR 55](https://github.com/opscode-cookbooks/jenkins/pull/55) is merged.
