### PR TITLE
Add debug logging on connection refused to show the URL that failed

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -47,6 +47,7 @@ module JenkinsHelper
       return false
     end
   rescue EOFError, Errno::ECONNREFUSED
+    Chef::Log.debug("GET to #{url} failed with connection refused")
     return false
   end
 end


### PR DESCRIPTION
While debugging a problem with a hung Jenkins deployment, it was very helpful to have the URL logged in the debug log.
