### PR TITLE
[COOK-3576] Clarrifying docs on server_auth_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Attributes
 * `node['jenkins']['http_proxy']['client_max_body_size']` - max client upload 
   size ("1024m" by default, nginx only). 
 * `node['jenkins']['http_proxy']['server_auth_method']` - Authentication with
-  the server can be done with cas (using `apache2::mod_auth_cas`), or htauth
-  (basic). The default is no authentication.
+  the server can be done with cas (using `apache2::mod_auth_cas`), or basic
+  (using `htpasswd`). The default is no authentication.
 * `node['jenkins']['http_proxy']['basic_auth_username']` - Username to use for
   HTTP Basic Authenitcation.
 * `node['jenkins']['http_proxy']['basic_auth_password']` - Password to use with


### PR DESCRIPTION
Standardizing how `node['jenkins']['http_proxy']['basic_auth_username']` is explained so that's it's presented as: `option` (how it's implemented)".
