### PR TITLE
[COOK-3587] Adding minitest-handler to the runlist for the node suite in Jenkins cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -133,6 +133,7 @@ suites:
   run_list:
   - recipe[jenkins::server]
   - recipe[jenkins::node]
+  - recipe[minitest-handler]
   attributes:
     jenkins:
       node:


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3587

Just adding the minitest-handler cookbook to the runlist for the node suite in the kitchen YAML so that tests are run after convergence. The tests already exist from a previous commit (for issue 3443).
