### PR TITLE
[COOK-3619] Support intermediate SSL certificates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,6 +75,7 @@ suites:
   - recipe[jenkins-test::generate_certs]
   - recipe[jenkins::server]
   - recipe[jenkins::proxy]
+  - recipe[minitest-handler]
   attributes:
     jenkins:
       http_proxy:
@@ -109,6 +110,7 @@ suites:
   - recipe[jenkins-test::generate_certs]
   - recipe[jenkins::server]
   - recipe[jenkins::proxy]
+  - recipe[minitest-handler]
   attributes:
     jenkins:
       http_proxy:
@@ -117,6 +119,7 @@ suites:
         ssl:
           enabled: true
           redirect_http: true
+          ca_cert_path: /var/lib/jenkins/ssl/jenkins.cert
 - name: server-proxy-apache2-basicauth
   run_list:
   - recipe[jenkins::server]

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Attributes
   the server can be done with cas (using `apache2::mod_auth_cas`), or basic
   (using `htpasswd`). The default is no authentication.
 * `node['jenkins']['http_proxy']['basic_auth_username']` - Username to use for
-  HTTP Basic Authenitcation.
+  HTTP Basic Authentication.
 * `node['jenkins']['http_proxy']['basic_auth_password']` - Password to use with
-  HTTP Basic Authenitcation.
+  HTTP Basic Authentication.
 * `node['jenkins']['http_proxy']['cas_login_url']` - Login url for cas if using
   cas authentication.
 * `node['jenkins']['http_proxy']['cas_validate_url']` - Validation url for cas
@@ -77,6 +77,14 @@ Attributes
   the server cert. Defaults to off.
 * `node['jenkins']['http_proxy']['cas_root_proxy_url']` - If set, sets the url
   that the cas server redirects to after auth.
+* `node['jenkins']['http_proxy']['ssl']['enabled']` - Configures jenkins to use SSL. This
+  cookbook expects you to provide your own certificates. You can tell Jenkins where your
+  certificates with the below attributes.
+* `node['jenkins']['http_proxy']['ssl']['cert_path']` - The path to your SSL certificate.
+* `node['jenkins']['http_proxy']['ssl']['key_path']` - The path to your SSL key.
+* `node['jenkins']['http_proxy']['ssl']['ca_cert_path']` - If set, configures apache
+  to use an intermediate certificate authority. Nginx does not use this attribute and expects any
+  intermediate certificates to be appended in the same file as your SSL certificate.
 
 ### Node/Slave related Attributes
 

--- a/files/default/test/server_test.rb
+++ b/files/default/test/server_test.rb
@@ -37,6 +37,28 @@ describe 'jenkins::server' do
       end
     end
 
+    it "configures ssl properly if configured to" do
+      if node['jenkins']['http_proxy']['ssl']['enabled']
+        case node['jenkins']['http_proxy']['variant']
+        when "apache"
+          file(File.join(node['apache']['dir'], "sites-available/jenkins")).must_include(
+            "SSLCertificateFile #{node['jenkins']['http_proxy']['ssl']['cert_path']}")
+          file(File.join(node['apache']['dir'], "sites-available/jenkins")).must_include(
+            "SSLCertificateKeyFile #{node['jenkins']['http_proxy']['ssl']['key_path']}")
+          if node['jenkins']['http_proxy']['ca_cert_path']
+            file(File.join(node['apache']['dir'], "sites-available/jenkins")).must_include(
+              "SSLCACertificateFile #{node['jenkins']['http_proxy']['ssl']['ca_cert_path']}")
+          end
+
+        when "nginx"
+          file(File.join(node['nginx']['dir'], "sites-available/jenkins.conf")).must_include(
+            "ssl_certificate     #{node['jenkins']['http_proxy']['ssl']['cert_path']}")
+          file(File.join(node['nginx']['dir'], "sites-available/jenkins.conf")).must_include(
+            "ssl_certificate_key #{node['jenkins']['http_proxy']['ssl']['key_path']}")
+        end
+      end
+    end
+
   end
 
   # Tests around directories

--- a/templates/default/apache_jenkins.erb
+++ b/templates/default/apache_jenkins.erb
@@ -31,6 +31,9 @@
   SSLEngine on
   SSLCertificateFile <%= node[:jenkins][:http_proxy][:ssl][:cert_path] %>
   SSLCertificateKeyFile <%= node[:jenkins][:http_proxy][:ssl][:key_path] %>
+  <% if node[:jenkins][:http_proxy][:ssl][:ca_cert_path] -%>
+  SSLCACertificateFile <%= node[:jenkins][:http_proxy][:ssl][:ca_cert_path] %>
+  <% end -%>
 
 </VirtualHost>
 <% end -%>


### PR DESCRIPTION
Add support for intermediate SSL certificates when using _proxy_apache recipe.
nginx doesn't have an equivalent to SSLCACertificateFile, they just expect you to concatenate your certificates together.

centos tests are failing due to COOK-3594
