### PR TITLE
[COOK-3623] Add a plugin resource/provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ Example:
       version '1.2'
     end
     
+    jenkins_plugin 'custom_plugin' do
+      version '0.3'
+      url 'http://myrepo/jenkins/plugins/0.3/custom_plugin.hpi'
+    end
+    
     jenkins_plugin 'envinject' do
       action :remove
     end

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -91,15 +91,14 @@ end
 
 
 def do_install_plugin
-  name = @new_resource.name
-  version = @new_resource.version
+  plugin_url = @new_resource.url
 
   # Plugins installed from the Jenkins Update Center are written to disk with
   # the `*.jpi` extension. Although plugins downloaded from the Jenkins Mirror
   # have an `*.hpi` extension we will save the plugins with a `*.jpi` extension
   # to match Update Center's behavior.
   remote_file plugin_file_path do
-    source "#{node['jenkins']['mirror']}/plugins/#{name}/#{version}/#{name}.hpi"
+    source plugin_url
     owner node['jenkins']['server']['user']
     group node['jenkins']['server']['group']
     backup false

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -71,6 +71,7 @@ node['jenkins']['server']['plugins'].each do |plugin|
   if plugin.is_a?(Hash)
     name = plugin['name']
     version = plugin['version'] if plugin['version']
+    url = plugin['url'] if plugin['url']
   else
     name = plugin
   end
@@ -78,6 +79,7 @@ node['jenkins']['server']['plugins'].each do |plugin|
   jenkins_plugin name do
     action :install
     version version if version
+    url url if url
   end
 end
 

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -21,3 +21,13 @@ actions :install, :remove
 default_action :install
 
 attribute :version, :kind_of => String
+attribute :url, :kind_of => String
+
+# If url isn't specified, a default URL based on the plugin name and version is returned
+def url(arg = nil)
+  if arg.nil? and @url.nil?
+    "#{node['jenkins']['mirror']}/plugins/#{name}/#{version}/#{name}.hpi"
+  else
+    set_or_return(:url, arg, :kind_of => String)
+  end
+end


### PR DESCRIPTION
This adds a `jenkins_plugin` resource/provider.  This allows adding and removing plugins with:

``` ruby
    # Install the latest version of greenballs
    jenkins_plugin 'greenballs'

    # Install version 1.2 of ant
    jenkins_plugin 'ant' do
      action :install
      version '1.2'
    end

    # Uninstall the envinject plugin
    jenkins_plugin 'envinject' do
      action :remove
    end
```

If you specify an explicit version, the plugin will be updated (thus making this a possible replacement for https://github.com/opscode-cookbooks/jenkins/pull/73).  It also pins plugins which allows updating system plugins.

NOTE:  If you set version to `latest` (default), the latest version will be installed, but the plugin will never be updated.  For now, you should use explicit versions to update plugins.

This is backwards compatible with the `node['jenkins']['server']['plugins']` attribute.

Fixes [COOK-3623](https://tickets.opscode.com/browse/COOK-3623)
