### PR TITLE
Jenkins Recipe is failing due Plugin version checking.

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -64,7 +64,7 @@ private
     manifest_file = ::File.join(plugins_dir, @current_resource.name, 'META-INF', 'MANIFEST.MF')
     if ::File.exist?(manifest_file)
       manifest = IO.read(manifest_file)
-      current_version = manifest.match(/^Plugin-Version:\s*(.+)$/).strip
+      current_version = if manifest.match(/^Plugin-Version:\s*(.+)$/) then $1.strip else "" end
     end
     current_version
   end


### PR DESCRIPTION
... `strip` method.

Current version fails since a `match` returns a `DataMatch` which has no `strip` method.
