### PR TITLE
[COOK-3701] Use pure node attributes in `_apache_common` and `apache_jenkins` templates

### DIFF
--- a/recipes/_proxy_apache2.rb
+++ b/recipes/_proxy_apache2.rb
@@ -55,11 +55,7 @@ template "#{node['apache']['dir']}/sites-available/jenkins" do
   mode        '0644'
   variables(
     :host_name        => host_name,
-    :host_aliases     => node['jenkins']['http_proxy']['host_aliases'],
     :www_redirect     => www_redirect,
-    :redirect_http    => node['jenkins']['http_proxy']['ssl']['redirect_http'],
-    :ssl_enabled      => node['jenkins']['http_proxy']['ssl']['enabled'],
-    :ssl_listen_ports => node['jenkins']['http_proxy']['ssl']['ssl_listen_ports']
   )
 
   if File.exists?("#{node['apache']['dir']}/sites-enabled/jenkins")

--- a/templates/default/_apache_common.erb
+++ b/templates/default/_apache_common.erb
@@ -1,6 +1,6 @@
   ServerName        <%= @host_name %>
   ProxyRequests     Off
-<% @host_aliases.each do |a| -%>
+<% node['jenkins']['http_proxy']['host_aliases'].each do |a| -%>
   ServerAlias       <%= a %>
 <% end -%>
 
@@ -8,16 +8,16 @@
   # Local reverse proxy authorization override
   # Most unix distribution deny proxy by default
   # (ie /etc/apache2/mods-enabled/proxy.conf in Ubuntu)
-  <Proxy http://localhost:<%= @jenkins_port %>/*>
+  <Proxy http://localhost:<%= node['jenkins']['server']['port'] %>/*>
     Order deny,allow
     Allow from all
   </Proxy>
 
   ProxyPreserveHost on
-  ProxyPass         /  http://localhost:<%= @jenkins_port %>/
-  ProxyPassReverse  /  http://localhost:<%= @jenkins_port %>/
+  ProxyPass         /  http://localhost:<%= node['jenkins']['server']['port'] %>/
+  ProxyPassReverse  /  http://localhost:<%= node['jenkins']['server']['port'] %>/
   ProxyPassReverse  /  http://<%= @host_name %>/
-<% @host_aliases.each do |a| -%>
+<% node['jenkins']['http_proxy']['host_aliases'].each do |a| -%>
   ProxyPassReverse  /  http://<%= a%>
 <% end -%>
 
@@ -39,7 +39,7 @@
     AuthType basic
     AuthName "Jenkins"
     AuthBasicProvider file
-    AuthUserFile <%= File.join(node.apache.dir, "htpasswd") %>
+    AuthUserFile <%= File.join(node['apache']['dir'], 'htpasswd') %>
     require valid-user
   </Location>
 <% end -%>

--- a/templates/default/apache_jenkins.erb
+++ b/templates/default/apache_jenkins.erb
@@ -1,7 +1,7 @@
 <% if @www_redirect -%>
 <VirtualHost *:80>
   ServerName        www.<%= @host_name %>
-<% @host_aliases.each do |a| -%>
+<% node['jenkins']['http_proxy']['host_aliases'].each do |a| -%>
   ServerAlias       www.<%= a %>
 <% end -%>
 
@@ -12,21 +12,21 @@
 
 <% end -%>
 <VirtualHost *:80>
-<% if @redirect_http -%>
+<% if node['jenkins']['http_proxy']['ssl']['redirect_http'] -%>
   RewriteEngine On
   # rewrite non ssl -> ssl
   RewriteCond %{HTTPS} off
   RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 <% end -%>
 
-<%= render "_apache_common.erb" %>
+<%= render '_apache_common.erb' %>
 
 </VirtualHost>
 
-<% if @ssl_enabled -%>
-<VirtualHost *:<%= @ssl_listen_ports.join ' *:' %>>
+<% if node['jenkins']['http_proxy']['ssl']['enabled'] -%>
+<VirtualHost *:<%= node['jenkins']['http_proxy']['ssl']['ssl_listen_ports'].join(' *:') %>>
 
-<%= render "_apache_common.erb" %>
+<%= render '_apache_common.erb' %>
 
   SSLEngine on
   SSLCertificateFile <%= node['jenkins']['http_proxy']['ssl']['cert_path'] %>


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3701

Originally presented in https://github.com/opscode-cookbooks/jenkins/commit/65cefad7259fe6dd75bd89643a2ebf6211b56cc3#commitcomment-4222187, a refactor due to a foodcritic recipe removed a template variable that was being used by a nested partial. Switching to node attributes eliminates this problem, makes foodcritic happy, and prevents people from questioning "now 
where did that variable come from?"
