### PR TITLE
[COOK-3841] Add a HOME variable for nodes started with JNLP

### DIFF
--- a/templates/default/sv-jenkins-slave-run.erb
+++ b/templates/default/sv-jenkins-slave-run.erb
@@ -2,6 +2,7 @@
 exec 2>&1
 cd <%= node['jenkins']['node']['home'] %>
 exec chpst -u <%= node['jenkins']['node']['user'] %> \
+  env HOME=<%= node['jenkins']['node']['home'] %> \
   java -jar <%= node['jenkins']['node']['home'] %>/slave.jar \
   -jnlpUrl <%= node['jenkins']['server']['url'] %>/computer/<%= node['jenkins']['node']['name'] %>/slave-agent.jnlp \
   <%= !@options[:secret] || @options[:secret].empty? ? '' : "-secret #{@options[:secret]}" %> \


### PR DESCRIPTION
Runit's chpst clears environment variables so we need to set this explicitly.  Not having a `HOME` variable can cause a problem with some jobs.  For example, Ruby's expand_path method will fail.

https://tickets.opscode.com/browse/COOK-3841
