### PR TITLE
[COOK-3968] Support jenkins user's $HOME being different than $JENKINS_HOME

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,62 @@ platforms:
   - name: centos-5.9
 
 suites:
+  - name: server_package_differentjhome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        server:
+          home: /opt/jenkins
+          install_method: package
+          plugins:
+          - name: git-client
+            version: 1.0.5
+          - name: git
+            version: 1.3.0
+  - name: server_war_differentjhome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        server:
+          home: /opt/jenkins
+          install_method: war
+          plugins:
+          - name: git-client
+            version: 1.0.5
+          - name: git
+            version: 1.3.0
+  - name: server_package_differenthome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        server:
+          home_dir: /home/jenkins
+          install_method: package
+          plugins:
+          - name: git-client
+            version: 1.0.5
+          - name: git
+            version: 1.3.0
+  - name: server_war_differenthome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        server:
+          home_dir: /home/jenkins
+          install_method: war
+          plugins:
+          - name: git-client
+            version: 1.0.5
+          - name: git
+            version: 1.3.0
   - name: server_package
     run_list:
     - recipe[jenkins::server]
@@ -119,6 +175,35 @@ suites:
           server_auth_method: basic
           basic_auth_username: foo
           basic_auth_password: bar
+  - name: node-differentjhome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[jenkins::node]
+    - recipe[jenkins-test::generate_sshkey]
+    - recipe[jenkins-test::generate_user]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        node:
+          home: /opt/jenkins_home
+          home_dir: /opt/jenkins
+          ssh_private_key: /home/jenkins/.ssh/id_rsa
+          env:
+            foo: bar
+  - name: node-differenthome
+    run_list:
+    - recipe[jenkins::server]
+    - recipe[jenkins::node]
+    - recipe[jenkins-test::generate_sshkey]
+    - recipe[jenkins-test::generate_user]
+    - recipe[minitest-handler]
+    attributes:
+      jenkins:
+        node:
+          home: /opt/jenkins
+          ssh_private_key: /home/jenkins/.ssh/id_rsa
+          env:
+            foo: bar
   - name: node
     run_list:
     - recipe[jenkins::server]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Attributes
 
 * `node['jenkins']['server']['install_method']` - Whether Jenkins is installed from packages or run from a WAR file.
 * `node['jenkins']['server']['home']` - Location of `JENKINS_HOME` directory.
+* `node['jenkins']['server']['home']` - Location of the jenkins user `HOME` directory.
 * `node['jenkins']['server']['user']` - User the Jenkins server runs as.
 * `node['jenkins']['server']['group']` - Jenkins user primary group.
 * `node['jenkins']['server']['port']` - TCP port Jenkins server listens on.
@@ -67,7 +68,8 @@ Attributes
 * `node['jenkins']['node']['name']` - Name of the node within Jenkins.
 * `node['jenkins']['node']['description']` - Jenkins node description.
 * `node['jenkins']['node']['executors']` - Number of node executors.
-* `node['jenkins']['node']['home]` - Home directory ("Remote FS root") of the node.
+* `node['jenkins']['node']['home']` - JENKINS_HOME directory ("Remote FS root") of the node.
+* `node['jenkins']['node']['home_dir']` - Home directory for the jenkins user.
 * `node['jenkins']['node']['labels']` - Node labels.
 * `node['jenkins']['node']['mode']` - Node usage mode, `normal` or `exclusive` (tied jobs only).
 * `node['jenkins']['node']['availability']` - `always` keeps node on-line, `demand` off-lines when idle.

--- a/attributes/node.rb
+++ b/attributes/node.rb
@@ -41,6 +41,7 @@ else
   default['jenkins']['node']['agent_type'] = 'jnlp'
 end
 
+default['jenkins']['node']['home_dir'] = node['jenkins']['node']['home']
 default['jenkins']['node']['user'] = 'jenkins-node'
 default['jenkins']['node']['group'] = 'jenkins-node'
 default['jenkins']['node']['shell'] = '/bin/sh'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -23,6 +23,7 @@
 #
 
 default['jenkins']['server']['home'] = '/var/lib/jenkins'
+default['jenkins']['server']['home_dir'] = node['jenkins']['server']['home']
 default['jenkins']['server']['log_dir'] = '/var/log/jenkins'
 
 default['jenkins']['server']['user'] = 'jenkins'

--- a/files/default/test/server_test.rb
+++ b/files/default/test/server_test.rb
@@ -7,7 +7,7 @@ describe 'jenkins::server' do
   describe 'users and groups' do
     # Check if the jenkins user was created with the correct home path
     it 'should create the jenkins user with the correct home path' do
-      user('jenkins').must_exist.with(:home, node['jenkins']['server']['home'])
+      user('jenkins').must_exist.with(:home, node['jenkins']['server']['home_dir'])
     end
   end
 
@@ -60,9 +60,14 @@ describe 'jenkins::server' do
       home_dir = node['jenkins']['server']['home']
       plugins_dir = File.join(home_dir, 'plugins')
       log_dir = node['jenkins']['server']['log_dir']
-      ssh_dir = File.join(home_dir, '.ssh')
+      ssh_dir = File.join(node['jenkins']['server']['home_dir'], '.ssh')
 
       directory(home_dir).must_exist.with(
+          :owner, node['jenkins']['server']['user']).and(
+          :group, node['jenkins']['server']['home_dir_group']).and(
+          :mode, node['jenkins']['server']['dir_permissions'])
+
+      directory(node['jenkins']['server']['home_dir']).must_exist.with(
           :owner, node['jenkins']['server']['user']).and(
           :group, node['jenkins']['server']['home_dir_group']).and(
           :mode, node['jenkins']['server']['dir_permissions'])

--- a/recipes/_node_ssh.rb
+++ b/recipes/_node_ssh.rb
@@ -48,14 +48,20 @@ directory node['jenkins']['node']['home'] do
   action :create
 end
 
-directory "#{node['jenkins']['node']['home']}/.ssh" do
+directory node['jenkins']['node']['home_dir'] do
+  owner node['jenkins']['node']['user']
+  group node['jenkins']['node']['group']
+  action :create
+end
+
+directory "#{node['jenkins']['node']['home_dir']}/.ssh" do
   owner node['jenkins']['node']['user']
   group node['jenkins']['node']['group']
   mode '0700'
   action :create
 end
 
-file "#{node['jenkins']['node']['home']}/.ssh/authorized_keys" do
+file "#{node['jenkins']['node']['home_dir']}/.ssh/authorized_keys" do
   content node['jenkins']['server']['pubkey']
   owner node['jenkins']['node']['user']
   group node['jenkins']['node']['group']

--- a/recipes/_node_windows.rb
+++ b/recipes/_node_windows.rb
@@ -34,7 +34,7 @@ end
 
 env 'JENKINS_HOME' do
   action :create
-  value home_dir
+  value node['jenkins']['node']['home']
 end
 
 env 'JENKINS_URL' do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -28,15 +28,21 @@
 include_recipe 'java::default'
 
 user node['jenkins']['server']['user'] do
-  home node['jenkins']['server']['home']
+  home node['jenkins']['server']['home_dir']
 end
 
-home_dir = node['jenkins']['server']['home']
-plugins_dir = File.join(home_dir, 'plugins')
+plugins_dir = File.join(node['jenkins']['server']['home'], 'plugins')
 log_dir = node['jenkins']['server']['log_dir']
-ssh_dir = File.join(home_dir, '.ssh')
+ssh_dir = File.join(node['jenkins']['server']['home_dir'], '.ssh')
 
-directory home_dir do
+directory node['jenkins']['server']['home'] do
+  owner node['jenkins']['server']['user']
+  group node['jenkins']['server']['home_dir_group']
+  mode node['jenkins']['server']['dir_permissions']
+  recursive true
+end
+
+directory node['jenkins']['server']['home_dir'] do
   owner node['jenkins']['server']['user']
   group node['jenkins']['server']['home_dir_group']
   mode node['jenkins']['server']['dir_permissions']

--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -3,7 +3,7 @@ exec 2>&1
 cd <%= node['jenkins']['server']['home'] %>
 touch jenkins.start
 exec chpst -u <%= node['jenkins']['server']['user'] %> -U <%= node['jenkins']['server']['user'] %> \
-  env HOME=<%= node['jenkins']['server']['home'] %> \
+  env HOME=<%= node['jenkins']['server']['home_dir'] %> \
   JENKINS_HOME=<%= node['jenkins']['server']['home'] %> \
   java <%= node['jenkins']['server']['jvm_options'] %> -jar jenkins.war \
   -Xloggc:<%= node['jenkins']['server']['log_dir'] %>/gclog.log \


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3968

Though it is a good pattern to have the $JENKINS_HOME be the same as the dedicated jenkins user's $HOME, there are some cases that it doesn't make sense. (think corporate IT)

I did my best to make this change backwards compatible. I also added documentation to the README and added some test kitchen suites. It should also pass foodcritic.
