### PR TITLE
[COOK-3963] don't use dangerous methods in `jenkins_node_defaults`

### DIFF
--- a/libraries/manage_node.rb
+++ b/libraries/manage_node.rb
@@ -30,8 +30,8 @@ def jenkins_node_defaults(args)
   args[:launcher] ||= 'jnlp' # 'jnlp' or 'command' or 'ssh'
   args[:availability] ||= 'Always' # 'Always' or 'Demand'
   args[:env] = args[:env] ? args[:env].to_hash : nil
-  args[:mode].upcase!
-  args[:availability].capitalize!
+  args[:mode] = args[:mode].upcase
+  args[:availability] = args[:availability].capitalize
 
   if args[:availability] == 'Demand'
     args[:in_demand_delay] ||= 0


### PR DESCRIPTION
the `args` passed to the `jenkins_node_defaults` method could have been set using a node attribute. Using dangerous methods (such as `upcase!`) will actually change the node attribute at whatever level (default, normal, override, etc) it came from. This is bad.
