### PR TITLE
[COOK-3964] allow platform labels to not be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Attributes
 * `node['jenkins']['node']['executors']` - Number of node executors.
 * `node['jenkins']['node']['home]` - Home directory ("Remote FS root") of the node.
 * `node['jenkins']['node']['labels']` - Node labels.
+* `node['jenkins']['node']['add_platform_labels']` - Add useful labels based on the platform. (default is `true`)
 * `node['jenkins']['node']['mode']` - Node usage mode, `normal` or `exclusive` (tied jobs only).
 * `node['jenkins']['node']['availability']` - `always` keeps node on-line, `demand` off-lines when idle.
 * `node['jenkins']['node']['in_demand_delay']` - number of minutes for which jobs must be waiting in the queue before attempting to launch this slave.

--- a/attributes/node.rb
+++ b/attributes/node.rb
@@ -50,6 +50,7 @@ default['jenkins']['node']['description'] =
   "[#{node['kernel']['os']} #{node['kernel']['release']} #{node['kernel']['machine']}] " <<
   "slave on #{node['hostname']}"
 default['jenkins']['node']['labels'] = (node['tags'] || [])
+default['jenkins']['node']['add_platform_labels'] = true
 
 default['jenkins']['node']['env'] = nil
 default['jenkins']['node']['jvm_options'] = nil

--- a/providers/node.rb
+++ b/providers/node.rb
@@ -22,8 +22,10 @@
 
 def load_current_resource
   @current_resource = Chef::Resource::JenkinsNode.new(@new_resource.name)
-  # Inject some useful platform labels
-  @new_resource.labels((@new_resource.labels + platform_labels).uniq)
+  if node['jenkins']['node']['add_platform_labels']
+    # Inject some useful platform labels
+    @new_resource.labels((@new_resource.labels + platform_labels).uniq)
+  end
   @current_resource
 end
 


### PR DESCRIPTION
add node attribute that allows the jenkins node labels for the platform to not be automatically added to the node.
