### PR TITLE
[COOK-3795] use ssh credentials in jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Attributes
 * `node['jenkins']['node']['ssh_user']` - SSH slave user name (only required if Jenkins server and slave user is different).
 * `node['jenkins']['node']['ssh_pass']` - SSH slave password (not required when server is installed via `jenkins::server` recipe).
 * `node['jenkins']['node']['ssh_private_key']` - Jenkins Master defaults to: `JENKINS_HOME/.ssh/id_rsa` (created by the `jenkins::server` recipe).
+* `node['jenkins']['node']['ssh_credentials_description']` - The description given to the SSH credentials in Jenkins' credentials manager. (default is `chef`)
 * `node['jenkins']['node']['jvm_options']` - Additional tuning parameters to pass the underlying JVM process.
 
 ### Windows Node/Slave related Attributes

--- a/attributes/node.rb
+++ b/attributes/node.rb
@@ -70,6 +70,7 @@ default['jenkins']['node']['availability'] = 'always'
 # SSH options
 default['jenkins']['node']['ssh_host'] = node['fqdn']
 default['jenkins']['node']['ssh_port'] = 22
+default['jenkins']['node']['ssh_credentials_description'] = 'chef'
 default['jenkins']['node']['ssh_user'] = default['jenkins']['node']['user']
 default['jenkins']['node']['ssh_pass'] = nil
 default['jenkins']['node']['ssh_private_key'] = nil

--- a/files/default/node_info.groovy
+++ b/files/default/node_info.groovy
@@ -37,6 +37,17 @@ def toJSON(node) {
   }
 }
 
+def sshCredentialsDescription(slave) {
+  if (Jenkins.instance.pluginManager.getPlugin('ssh-credentials')) {
+    try {
+      return slave.launcher.credentials.description
+    } catch (NullPointerException e) {
+      // this is if the ssh credentials are broken from before COOK-3795 was fixed
+      return null
+    }
+  } else { return null }
+}
+
 slave = Jenkins.instance.getNode(this.args[0]) as Slave
 
 if (slave == null) {
@@ -78,6 +89,7 @@ else {
     node["launcher"] = "ssh"
     node["host"] = launcher.host
     node["port"] = launcher.port
+    node["credentials_description"] = sshCredentialsDescription(slave)
     node["username"] = launcher.username
     if (launcher.password != null) {
       node["password"] = launcher.password

--- a/recipes/_node_ssh.rb
+++ b/recipes/_node_ssh.rb
@@ -79,4 +79,5 @@ jenkins_node node['jenkins']['node']['name'] do
   password     node['jenkins']['node']['ssh_pass']
   private_key  node['jenkins']['node']['ssh_private_key']
   jvm_options  node['jenkins']['node']['jvm_options']
+  credentials_description node['jenkins']['node']['ssh_credentials_description']
 end

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -45,6 +45,7 @@ attribute :username, :kind_of => String
 attribute :password, :kind_of => String
 attribute :private_key, :kind_of => String
 attribute :jvm_options, :kind_of => String
+attribute :credentials_description, :kind_of => String
 
 def initialize(name, run_context = nil)
   super


### PR DESCRIPTION
change the node_info and manage_node to find the credentials description for the ssh slave if it uses ssh credentials.
