### PR TITLE
Allow a jenkins plugin to not be pinned.

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -102,10 +102,12 @@ private
       notifies :create, 'ruby_block[block_until_operational]'
     end
 
-    file "#{plugin_file_path}.pinned" do
-      action :create_if_missing
-      owner node['jenkins']['server']['user']
-      group node['jenkins']['server']['group']
+    if @new_resource.pinned
+      file "#{plugin_file_path}.pinned" do
+        action :create_if_missing
+        owner node['jenkins']['server']['user']
+        group node['jenkins']['server']['group']
+      end
     end
   end
 

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -22,6 +22,7 @@ default_action :install
 
 attribute :version, :kind_of => String
 attribute :url, :kind_of => String
+attribute :pinned, :kind_of => [TrueClass, FalseClass], :default => true
 
 # If url isn't specified, a default URL based on the plugin name and version is returned
 def url(arg = nil)


### PR DESCRIPTION
I created [COOK-3980](https://tickets.opscode.com/browse/COOK-3980) to track this.

I've also signed the necessary contributor agreements.
