### PR TITLE
Avoid a jenkins_cli "safe-restart" every time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ This resource can be used to execute the Jenkins cli from your recipes. For exam
 ```ruby
 %w(git URLSCM build-publisher).each do |plugin|
   jenkins_cli "install-plugin #{plugin}"
-  jenkins_cli "safe-restart"
 end
+
+jenkins_cli "safe-restart"
 ```
 
 ### jenkins_node


### PR DESCRIPTION
Performing a `jenkins_cli "safe-restart"` every time you install a plugin will fail soon enough. 
The jenkins restart takes some time and it only needs to be done after installing all the plugins, not each ;)
