### PR TITLE
[COOK-3993] Adding the posibility to install stable (LTS) jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Attributes
 ### Master/Server related Attributes
 
 * `node['jenkins']['server']['install_method']` - Whether Jenkins is installed from packages or run from a WAR file.
-* `node['jenkins']['server']['use_stable']` - Download stable version of WAR, applicable only to WAR install method.
+* `node['jenkins']['server']['use_stable']` - Use the stable (Long-Term Support) version of Jenkins
 * `node['jenkins']['server']['home']` - Location of `JENKINS_HOME` directory.
 * `node['jenkins']['server']['user']` - User the Jenkins server runs as.
 * `node['jenkins']['server']['group']` - Jenkins user primary group.

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -40,7 +40,6 @@ when 'debian'
   default['jenkins']['server']['ssh_dir_group'] = 'nogroup'
 when 'rhel'
   default['jenkins']['server']['install_method'] = 'package'
-  default['jenkins']['server']['use_stable'] = true
   default['jenkins']['server']['group'] = default['jenkins']['server']['user']
   default['jenkins']['server']['config_path'] = '/etc/sysconfig/jenkins'
   default['jenkins']['server']['config_template'] = 'sysconfig.erb'
@@ -61,6 +60,7 @@ end
 
 default['jenkins']['server']['version'] = nil
 default['jenkins']['server']['war_checksum'] = nil
+default['jenkins']['server']['use_stable'] = false
 
 default['jenkins']['server']['port'] = 8080
 default['jenkins']['server']['host'] = node['fqdn']

--- a/recipes/_server_package.rb
+++ b/recipes/_server_package.rb
@@ -23,7 +23,7 @@ when 'debian'
   include_recipe 'apt::default'
 
   apt_repository 'jenkins' do
-    uri 'http://pkg.jenkins-ci.org/debian'
+    uri 'http://pkg.jenkins-ci.org/' + (node['jenkins']['server']['use_stable'] ? 'debian-stable' : 'debian')
     distribution 'binary/'
     components ['']
     key 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
@@ -39,7 +39,7 @@ when 'rhel'
   end
 
   yum_repository 'jenkins-ci' do
-    url 'http://pkg.jenkins-ci.org/redhat'
+    url 'http://pkg.jenkins-ci.org/' + (node['jenkins']['server']['use_stable'] ? 'redhat-stable' : 'redhat')
     key 'RPM-GPG-KEY-jenkins-ci'
     action :add
   end

--- a/recipes/_server_war.rb
+++ b/recipes/_server_war.rb
@@ -26,14 +26,10 @@
 include_recipe 'runit::default'
 
 war_version = node['jenkins']['server']['version'].nil? ? 'latest' : node['jenkins']['server']['version']
+war_variant = node['jenkins']['server']['use_stable'] ? 'war-stable' : 'war'
 
 remote_file File.join(node['jenkins']['server']['home'], 'jenkins.war') do
-  if node['jenkins']['server']['use_stable']
-    source "#{node['jenkins']['mirror']}/war-stable/#{war_version}/jenkins.war"
-  else
-    source "#{node['jenkins']['mirror']}/war/#{war_version}/jenkins.war"
-  end
-
+  source "#{node['jenkins']['mirror']}/#{war_variant}/#{war_version}/jenkins.war"
   checksum node['jenkins']['server']['war_checksum'] unless node['jenkins']['server']['war_checksum'].nil?
   owner node['jenkins']['server']['user']
   group node['jenkins']['server']['home_dir_group']


### PR DESCRIPTION
Add an attribute `default['jenkins']['server']['use_stable']`, which then installs a Jenkins LTS/stable version.
