### PR TITLE
Update _proxy_apache2.rb

### DIFF
--- a/recipes/_proxy_apache2.rb
+++ b/recipes/_proxy_apache2.rb
@@ -25,7 +25,7 @@ www_redirect = (node['jenkins']['http_proxy']['www_redirect'] == 'enable')
 host_name = node['jenkins']['http_proxy']['host_name'] || node['fqdn']
 
 if node['jenkins']['http_proxy']['cas_validate_server'] == 'cas'
-  apache_module 'mod_auth_cas'
+  include_recipe 'apache2::mod_auth_cas'
 end
 
 if node['jenkins']['http_proxy']['ssl']['enabled']


### PR DESCRIPTION
Apache2 cookbook has a recipe to install and enable mod_auth_cas. Using it solves two problems I had using 'proxy' recipe: the module package wasn't installed and correct the name used as argument to apache_module action.
