### PR TITLE
fix(COOK-2636): Support jvm_options in sysvinit

### DIFF
--- a/templates/default/default.erb
+++ b/templates/default/default.erb
@@ -9,6 +9,7 @@ JAVA=/usr/bin/java
 # arguments to pass to java
 #JAVA_ARGS="-Xmx256m"
 #JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
+JAVA_ARGS="<%= node[:jenkins][:server][:jvm_options] %>"
 
 PIDFILE=/var/run/jenkins/jenkins.pid
 


### PR DESCRIPTION
This adds support for jvm_options to sysvinit scripts
