### PR TITLE
Use a custom URI joining method, since Ruby's sucks

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -69,6 +69,21 @@ EOH
     end
 
     #
+    # {URI.join} is a fucking nightmare. It rarely works. Using +File.join+ is
+    # cool for URLs, until someone is running on Windows and their URLs use the
+    # wrong slashes. This method attempts to cleanly join URI/URL segments into
+    # a cleanly normalized URL that the libraries can use when constructing
+    # URIs.
+    #
+    # @param [Array<String>] parts
+    #   the list of parts to join
+    #
+    def uri_join(*parts)
+      parts = parts.compact.map(&URI.method(:escape))
+      URI.parse(parts.join('/')).normalize.to_s
+    end
+
+    #
     # A Groovy snippet that will set the requested local Groovy variable
     # to an instance of the credentials represented by `username`.
     # Returns the Groovy `null` if no credentials are found.
@@ -271,7 +286,7 @@ EOH
     #
     def ensure_cli_present!
       node.run_state[:jenkins_cli_present] ||= begin
-        source = File.join(endpoint, 'jnlpJars', 'jenkins-cli.jar')
+        source = uri_join(endpoint, 'jnlpJars', 'jenkins-cli.jar')
         remote_file = Chef::Resource::RemoteFile.new(cli, run_context)
         remote_file.source(source)
         remote_file.backup(false)

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -493,8 +493,7 @@ class Chef
     # @return [String]
     #
     def slave_jar_url
-      path = ::File.join('jnlpJars', 'slave.jar')
-      URI.join(endpoint, path).to_s
+      @slave_jar_url ||= uri_join(endpoint, 'jnlpJars', 'slave.jar')
     end
 
     #

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -104,10 +104,7 @@ class Chef
     # @return [String]
     #
     def jnlp_url
-      return @jnlp_url if @jnlp_url
-      path = ::File.join(
-               'computer', new_resource.slave_name, 'slave-agent.jnlp')
-      @jnlp_url = URI.join(endpoint, path).to_s
+      @jnlp_url ||= uri_join(endpoint, 'computer', new_resource.slave_name, 'slave_agent.jnlp')
     end
 
     #


### PR DESCRIPTION
Refs: #129, #130, #131

Ruby's native `URI.join` method will strip any leading paths from the joining URI, meaning users working behind a proxy get stuck. In other words:

``` ruby
URI.join('http://localhost/jenkins', 'foo') #=> 'http://localhost/foo'
```

Notice that the `jenkins` is dropped? Whoever thought that was a good API?

This commit adds a new method, +uri_join+ on the helper class, that intelligently joins n-parts of a URL, URI-escaping each element for safety, and returning a normalized URI.
