### PR TITLE
output for jenkins_command

### DIFF
--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -49,7 +49,6 @@ class Chef
     def output(arg = nil)
       set_or_return(:output, arg, kind_of: String)
     end
-
   end
 end
 


### PR DESCRIPTION
I added an output attribute for  `jenkins_command` so we can capture and parse the stdout that is returned by a command.

``` ruby
command = jenkins_command 'who-am-i' do 
  notifies :create, 'ruby_block[test]'
end

ruby_block 'test' do 
  block do
   Chef::Log.info command.output
  end
end

```

will log a message like `Authenticated as: jenkins\n Authorities:`

I did this because I was trying to get the output of commands like `get-job` 

``` ruby
command = jenkins_command 'get-job template'
```

will return in `command.output` a whole xml file that can be used with `jenkins_job` to create other jobs using templates stored and managed by jenkins
