### PR TITLE
private_key will be used or ignored depending on if Jenkins authentication is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,14 +439,14 @@ key = OpenSSL::PKey::RSA.new(4096)
 private_key = key.to_pem
 public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
 
-# Create the Jenkins user with the public key
-jenkins_user 'chef' do
-  public_keys [public_key]
-end
-
 # Set the private key on the Jenkins executor
 ruby_block 'set private key' do
   block { node.set['jenkins']['executor']['private_key'] = private_key }
+end
+
+# Create the Jenkins user with the public key
+jenkins_user 'chef' do
+  public_keys [public_key]
 end
 ```
 

--- a/test/fixtures/cookbooks/authentication/recipes/default.rb
+++ b/test/fixtures/cookbooks/authentication/recipes/default.rb
@@ -10,15 +10,16 @@ key = OpenSSL::PKey::RSA.new(4096)
 private_key = key.to_pem
 public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
 
-# Create a default Chef user with the public key
-jenkins_user 'chef' do
-  full_name   'Chef Client'
-  public_keys [public_key]
-end
-
 # Set the private key on the executor
 ruby_block 'set the private key' do
   block { node.set['jenkins']['executor']['private_key'] = private_key }
+end
+
+# Create a default Chef user with the public key
+# For this to succeed PK needs to be automatically unset
+jenkins_user 'chef' do
+  full_name   'Chef Client'
+  public_keys [public_key]
 end
 
 # Turn on basic authentication
@@ -39,6 +40,7 @@ jenkins_script 'setup authentication' do
 end
 
 # Run some commands - this will ensure the CLI is correctly passing attributes
+# This will also ensure that the private key has been reset
 jenkins_command 'clear-queue'
 
 # Install a plugin


### PR DESCRIPTION
This commit allows a private key to be set for the Jenkins executor at the top of a wrapper cookbook.
The private key will then either be used or ignored by the executor, depending on if authentication is enabled on the Jenkins server.

The new setup for configuring authentication can now be:
A) configure the private key for the executor
B) configure a 'chef' user in Jenkins which has the corresponding public key (the private key will not be used)
C) configure authentication on the server (the private key will not be used)
D) add jobs/make config changes (the private key will now be used)

This change was needed to address the fact that the steps (1-3) shown below would fail on step #1 in the second run, as the private key had not yet been set at this point in the 2nd run:
1) configure a 'chef' user in Jenkins with the public key
2) configuring the private key for the executor
3) configure authentication on the server

Without this change, the new steps (A-D above) will fail on step B in the first run as the public key has not yet been loaded into Jenkins for the private key to authenticate with.
