### PR TITLE
Allow user more control over the plugin provider

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -108,6 +108,8 @@ suites:
     run_list: jenkins_plugin::enable
   - name: jenkins_plugin_install
     run_list: jenkins_plugin::install
+  - name: jenkins_plugin_install_no_restart
+    run_list: jenkins_plugin::install_no_restart
   - name: jenkins_plugin_uninstall
     run_list: jenkins_plugin::uninstall
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,30 @@ jenkins_plugin 'greenballs' do
 end
 ```
 
-**NOTE** You may need to restart Jenkins after changing a plugin. Because this varies on a case-by-case basis (and because everyone chooses to manage their Jenkins infrastructure differently) this LWRP does **NOT** restart Jenkins for you.
+By default this LWRP restarts jenkins after an install, uninstall, enable or disable of a plugin. It does this
+by sending a delayed notification to the `service[jenkins]` resource to restart. If you would like to avoid this restart you can set the `restart` attribute to `false`.
+
+```ruby
+jenkins_plugin 'greenballs' do
+  version '1.3'
+  restart false
+end
+
+```
+
+Additionally, you can pass `:immediately` to `restart` to cause an immediate restart.
+
+The jenkins CLI allows for a couple of options that can be passed to its `install-plugin` command. This is possible using the LWRP by passing an array to the `options` attribute. For example, to tell the LWRP not to restart jenkins and to pass the `-deploy` flag to `install-plugin`.
+
+```ruby
+  jenkins_plugin 'github-oauth' do
+    action :install
+    restart false
+    options ['-deploy']
+  end
+```
+
+`-deploy` tells install-plugin to attempt to deploy the plugin without restarting jenkins.
 
 ### jenkins_slave
 This resource manages Jenkins slaves, supporting the following actions:

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -39,6 +39,8 @@ class Chef
       # Set the name attribute and default attributes
       @name    = name
       @version = :latest
+      @restart = :delayed
+      @options = []
 
       # State attributes that are set by the provider
       @installed = false
@@ -80,6 +82,34 @@ class Chef
     #
     def source(arg = nil)
       set_or_return(:source, arg, kind_of: String)
+    end
+
+    #
+    # After installing, removing, enabling or disabling, should this plugin cause a restart and
+    # if so, how. Possible values:
+    #
+    #   :delayed - This is the default behavior. This looks for the service[jenkins]
+    #              resource and if found it will do a delayed notification on it.
+    #   :immediately - Look for the service[jenkins] resource and calls the restart action on it.
+    #   false - Do not attempt to restart Jenkins now or later.
+    #
+    # @param [Symbol, FalseClass] arg
+    # @return [Symbol, FalseClass]
+    #
+    def restart(arg = nil)
+      set_or_return(:restart, arg, kind_of: [Symbol, FalseClass], equal_to: [:delayed, :immediately, false])
+    end
+
+    #
+    # Options that will be passed to the install-plugin CLI call. For example,
+    #   -deploy - Deploy plugins right away without postponing them until the reboot.
+    #   -restart - Restart Jenkins upon successful installation
+    #
+    # @param [Array]
+    # #return [Array]
+    #
+    def options(arg = nil)
+      set_or_return(:options, arg, kind_of: [Array])
     end
 
     #
@@ -145,7 +175,7 @@ EOH
         # Jenkins that prevents Jenkins from following 302 redirects, so we
         # use Chef to download the plugin and then use Jenkins to install it.
         # It's a bit backwards, but so is Jenkins.
-        executor.execute!('install-plugin', escape(plugin.path), '-name', escape(new_resource.name))
+        executor.execute!('install-plugin', escape(plugin.path), '-name', escape(new_resource.name), new_resource.options)
       end
 
       if current_resource.installed?
@@ -154,11 +184,11 @@ EOH
           Chef::Log.debug("#{new_resource} already installed - skipping")
         else
           converge_by("Upgrade #{new_resource} from #{current_resource.version} to #{new_resource.version}", &block)
-          notify(:restart)
+          notify_restart
         end
       else
         converge_by("Install #{new_resource}", &block)
-        notify(:restart)
+        notify_restart
       end
     end
 
@@ -189,7 +219,7 @@ EOH
         converge_by("Disable #{new_resource}") do
           Resource::File.new(disabled, run_context).run_action(:create)
         end
-        notify(:restart)
+        notify_restart
       end
     end
 
@@ -212,7 +242,7 @@ EOH
         converge_by("Enable #{new_resource}") do
           Resource::File.new(disabled, run_context).run_action(:delete)
         end
-        notify(:restart)
+        notify_restart
       else
         Chef::Log.debug("#{new_resource} already enabled - skipping")
       end
@@ -242,7 +272,7 @@ EOH
           directory.recursive(true)
           directory.run_action(:delete)
         end
-        notify(:restart)
+        notify_restart
       else
         Chef::Log.debug("#{new_resource} not installed - skipping")
       end
@@ -320,25 +350,27 @@ EOH
     end
 
     #
-    # Restart the Jenkins master. If the +restart+ parameter is given, the
-    # master is restarted immediately. Otherwise, the master is restarted at
-    # the end of the Chef Client run.
+    # Restart the Jenkins master. If new_resource.restart is :immediately then
+    # run the restart action on the service[jenkins] resource. If it is :delayed
+    # then do a delayed notification.
     #
-    def notify(action)
-      begin
-        service = run_context.resource_collection.find('service[jenkins]')
-      rescue Chef::Exceptions::ResourceNotFound
-        Chef::Log.warn <<-EOH
-I could not find service[jenkins] in the resource collection. The
-`jenkins_plugin' resource tries to #{action} the Jenkins master automatically
-after a plugin is installed or modified, but requires that a service resource
-exists for `jenkins'. If you are using your own Jenkins installation method,
-you must manually create a Jenkins service resource.
-EOH
-        return
-      end
+    def notify_restart
+      unless new_resource.restart == false
+        begin
+          service = run_context.resource_collection.find('service[jenkins]')
+        rescue Chef::Exceptions::ResourceNotFound
+          Chef::Log.warn <<-EOH
+  I could not find service[jenkins] in the resource collection. The
+  `jenkins_plugin' resource tries to restart the Jenkins master automatically
+  after a plugin is installed or modified, but requires that a service resource
+  exists for `jenkins'. If you are using your own Jenkins installation method,
+  you must manually create a Jenkins service resource.
+  EOH
+          return
+        end
 
-      new_resource.notifies(action, service, :delayed)
+        new_resource.notifies(:restart, service, new_resource.restart)
+      end
     end
   end
 end

--- a/test/fixtures/cookbooks/jenkins_plugin/recipes/install_no_restart.rb
+++ b/test/fixtures/cookbooks/jenkins_plugin/recipes/install_no_restart.rb
@@ -1,0 +1,16 @@
+include_recipe 'jenkins::master'
+
+ruby_block "Save current running pid of jenkins to test for restart" do
+  block do
+    File.open('/tmp/kitchen/cache/install_no_restart.pid', 'w+') do |file|
+      file.write(`pgrep -f /usr/lib/jenkins/jenkins.war`.strip)
+    end
+  end
+end
+
+# Install plugin, don't restart and tell install-plugin to deploy the plugin
+jenkins_plugin 'disk-usage' do
+  version '0.23'
+  restart false
+  options ['-deploy']
+end

--- a/test/integration/jenkins_plugin_install_no_restart/serverspec/assert_installed_no_restart_spec.rb
+++ b/test/integration/jenkins_plugin_install_no_restart/serverspec/assert_installed_no_restart_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../kitchen/data/spec_helper'
+
+# Make sure the pid set before installing the plugin has not changed.
+describe file("/tmp/kitchen/cache/install_no_restart.pid") do
+  it { should contain `pgrep -f /usr/lib/jenkins/jenkins.war`.strip }
+end
+
+describe jenkins_plugin('disk-usage') do
+  it { should be_a_jenkins_plugin }
+end


### PR DESCRIPTION
- Allow user to pass options to the install-plugin call of the CLI.
- Allow user to specify if and how the restart notification is processed.
- Add integration test
- Update readme
