### PR TITLE
add random password generation for jenkins_user

### DIFF
--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -142,6 +142,10 @@ class Chef
 
             email = new hudson.tasks.Mailer.UserProperty('#{new_resource.email}')
             user.addProperty(email)
+            
+            def chars = [ 'A'..'Z', 'a'..'z', '0'..'9' ].flatten()
+            def password = (0..<20).collect { chars[ new Random().nextInt( chars.size() ) ] }.join()
+            user.addProperty(hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword(password))
 
             keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl('#{new_resource.public_keys.join("\n")}')
             user.addProperty(keys)


### PR DESCRIPTION
`jenkins-cli` cannot authorize by private key, if the password for the `jenkins` user is not set.

Jenkins throws exception if user password not set.

This patch generates secure random password for each new registered user by `jenkins_user` helper. 

https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java#L167
