### PR TITLE
spiff the jenkins_ssh_slave README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,9 @@ jenkins_ssh_slave 'executor' do
   labels      ['executor', 'freebsd', 'jail']
 
   # SSH specific attributes
-  host     '172.11.12.53' # or 'slave.example.org'
-  username 'jenkins'
+  host        '172.11.12.53' # or 'slave.example.org'
+  user        'jenkins'
+  credentials 'wcoyote'
 end
 
 # A slave's executors, usage mode and availability can also be configured


### PR DESCRIPTION
Touching up the jenkins_ssh_slave resource example in the README. In conversation with @schisamo, credentials is a required resource and username doesn't get recognized as an attribute (but user does).
