### PR TITLE
Avoid downloading jenkins key from jenkins mirror

### DIFF
--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -28,7 +28,8 @@ when 'debian'
   apt_repository 'jenkins' do
     uri          'http://pkg.jenkins-ci.org/debian'
     distribution 'binary/'
-    key          'https://jenkins-ci.org/debian/jenkins-ci.org.key'
+    key          '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6'
+    keyserver    'pool.sks-keyservers.net'
   end
 
   package 'jenkins' do


### PR DESCRIPTION
The URL for the .key isn't server over https, the URL redirects to http.
This also stops issues when trying to fetch the key file from the
jenkins main mirror that goes down quite often.

This PR is sort of in response to: https://github.com/opscode-cookbooks/jenkins/issues/180 and https://github.com/opscode-cookbooks/jenkins/issues/163
