### PR TITLE
Fix a bug in default windows domain name

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -128,7 +128,7 @@ class Chef
         user_domain = match[1]
         user_account   = match[2]
       else
-        user_domain = nil
+        user_domain = "."
         user_account   = new_resource.user
       end
 


### PR DESCRIPTION
Domain name default value is set to nil: when the cookbook generates
winsw xml file template domainname is set to "".

Unfortunately winsw ignore the whole  <serviceaccount> part of the
config when domain name is not specified or empty (see https://github.com/kohsuke/winsw/blob/master/ServiceDescriptor.cs#L573)

In the end, when domain is not specified in jenkins slave, user is
ignored and jenkins service will run as administrator..
