### PR TITLE
Fix a bug in windows jenkins slave service

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -36,7 +36,7 @@ class Chef
       @remote_fs = 'C:\jenkins'
       @user      = 'LocalSystem'
       @password  = nil
-      @winsw_url = 'http://repo.jenkins-ci.org/releases/com/sun/winsw/winsw/1.13/winsw-1.13-bin.exe'
+      @winsw_url = 'http://repo.jenkins-ci.org/releases/com/sun/winsw/winsw/1.16/winsw-1.16-bin.exe'
     end
 
     #


### PR DESCRIPTION
Domain name default value is set to nil: when the cookbook generates
winsw xml file template domainname is set to "".

Unfortunately winsw ignore the whole part of the
config when domain name is not specified or empty (see https://github.com/kohsuke/winsw/blob/master/ServiceDescriptor.cs#L573)

In the end, when domain is not specified in jenkins slave, user is
ignored and jenkins service will run as administrator..
