### PR TITLE
jenkins_ssh_slave support for launch_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,14 @@ jenkins_ssh_slave 'executor' do
   # SSH specific attributes
   host        '172.11.12.53' # or 'slave.example.org'
   user        'jenkins'
-  credentials 'wcoyote'
+
+  # use the UUID of a Jenkins "SYSTEM" level credential;
+  # this is useful if you create the credentials from an ERB template, like:
+  credentials '476f2a1d-6cc4-40af-aaaf-c72be6b2023c'
+
+  # an optional timeout of 60 seconds for the initial connection to the slave
+  # defaults to no timeout
+  launch_timeout 60
 end
 
 # A slave's executors, usage mode and availability can also be configured


### PR DESCRIPTION
- adds support for the SSH slave advanced setting "launch timeout", 
  which is the timeout that Jenkins will enforce when first trying to 
  connect to a slave; defaults to nil
- backwards compatible support for the ssh-slaves plugin prior to v1.6;
  v1.6 added support for timeouts
- resolves an issue with the jenkins creating a new set of
  ssh credentials with the credentials UUID as the new username
  instead of using the existing credentials id
