### PR TITLE
Instrumentation for groovy script execution

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -74,10 +74,19 @@ module Jenkins
       command << " -p #{uri_escape(options[:proxy])}"    if options[:proxy]
       command << " #{pieces.join(' ')}"
 
+      Chef::Log.debug("Jenkins::Executor::execute! - executing jenkins CLI call:")
+      Chef::Log.debug(command)
+
       command = Mixlib::ShellOut.new(command, timeout: options[:timeout])
       command.run_command
       command.error!
-      command.stdout.strip
+      result = command.stdout.strip
+
+      Chef::Log.debug("Jenkins::Executor::execute! - jenkins CLI returned #{command.exitstatus} with output:")
+      Chef::Log.debug(result)
+      Chef::Log.debug(command.stderr.strip)
+
+      result
     end
 
     #
@@ -106,6 +115,10 @@ module Jenkins
       file = Tempfile.new('groovy')
       file.write script
       file.flush
+
+      Chef::Log.debug("Jenkins::Executor::groovy! - created groovy script @ #{file.path}:")
+      Chef::Log.debug(script)
+
       execute!("groovy #{file.path}")
     ensure
       file.close! if file
@@ -120,6 +133,10 @@ module Jenkins
       file = Tempfile.new('groovy')
       file.write script
       file.flush
+
+      Chef::Log.debug("Jenkins::Executor::groovy - created groovy script @ #{file.path}:")
+      Chef::Log.debug(script)
+
       execute("groovy #{file.path}")
     ensure
       file.close! if file

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -16,7 +16,7 @@ describe Jenkins::Executor do
   end
 
   describe '#execute!' do
-    let(:shellout) { double(run_command: nil, error!: nil, stdout: '') }
+    let(:shellout) { double(run_command: nil, error!: nil, stdout: '', stderr: '', exitstatus: 0) }
     before { allow(Mixlib::ShellOut).to receive(:new).and_return(shellout) }
 
     context 'when no options are given' do


### PR DESCRIPTION
The Jenkins::Executor type now logs the input, return code, stdout stream,
and the stderr stream when the converge log_level is set to `debug`.
