### PR TITLE
Allow users to be created with already hashed passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ This resource manages Jenkins users, supporting the following actions:
 
 This uses the Jenkins groovy API to create users.
 
-The `:create` action idempotently creates a Jenkins user on the current node. The id attribute corresponds to the username of the id of the user on the target node. You may also specify a name, email, and list of SSH keys.
+The `:create` action idempotently creates a Jenkins user on the current node. The id attribute corresponds to the username of the id of the user on the target node. You may also specify a name, email, password, and list of SSH keys.  If hashed_password is set to true, the password will be passed in as-is.  If false, Jenkins will hash, and then store it.
 
 ```ruby
 # Create a Jenkins user

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -47,6 +47,9 @@ class Chef
       default: []
     attribute :password,
       kind_of: String
+    attribute :hashed_password,
+      kind_of: [TrueClass, FalseClass],
+      default: false
 
     attr_writer :exists
 
@@ -99,7 +102,7 @@ class Chef
             email = new hudson.tasks.Mailer.UserProperty('#{new_resource.email}')
             user.addProperty(email)
 
-            password = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword('#{new_resource.password}')
+            password = hudson.security.HudsonPrivateSecurityRealm.Details.#{new_resource.hashed_password ? 'fromHashedPassword' : 'fromPlainPassword'}('#{new_resource.password}')
             user.addProperty(password)
 
             keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl('#{new_resource.public_keys.join("\n")}')


### PR DESCRIPTION
This avoids the need to store plaintext passwords for Jenkins users managed by chef.
