### PR TITLE
jenkins master args are nil by default & we're left with a trailing slas...

### DIFF
--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -14,5 +14,4 @@ exec chpst -u <%= node['jenkins']['master']['user'] %> -U <%= node['jenkins']['m
   JENKINS_HOME=<%= node['jenkins']['master']['home'] %> \
   <%= node['jenkins']['java'] %> <%= node['jenkins']['master']['jvm_options'] %> -jar jenkins.war \
   --httpPort=<%= node['jenkins']['master']['port'] %> \
-  --httpListenAddress=<%= node['jenkins']['master']['listen_address'] %> \
-  <%= node['jenkins']['master']['jenkins_args'] %>
+  --httpListenAddress=<%= node['jenkins']['master']['listen_address'] %> <%= node['jenkins']['master']['jenkins_args'] %>


### PR DESCRIPTION
...h that breaks runit
