### PR TITLE
Bug on windows slaves when slave.jar changes.

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -209,6 +209,7 @@ class Chef
       @slave_jar_resource.source(slave_jar_url)
       @slave_jar_resource.backup(false)
       @slave_jar_resource.mode('0755')
+      @slave_jar_resource.atomic_update(false)
       @slave_jar_resource
     end
 


### PR DESCRIPTION
On Windows, when slave.jar changes on the master, the
'slave_jar_resource' remote_file will try to replace the file.
Usually, the file is already in use (since the jenkins slave is running).
That means we need to be careful about how we try to update this file.
I didn't investigate exactly why, but the atomic_update strategy seems to do something that the open file is not happy with (and I get a `Errno::EACCES: remote_file[C:\chef\cache/slave.jar]
(dynamically defined) had an error: Errno::EACCES: Permission denied` error).
This is why I am proposing to use the non atomic update strategy, which uses a simple cp and does not have this problem.
