### PR TITLE
Replace service notifications with runit_service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,20 @@ end
 
 Depending on the plugin, you may need to restart the Jenkins instance for the plugin to take affect:
 
+Package installation method:
+```ruby
+jenkins_plugin 'a_complicated_plugin' do
+  notifies :restart, 'service[jenkins]', :immediately
+end
+```
+
+War installation method:
 ```ruby
 jenkins_plugin 'a_complicated_plugin' do
   notifies :restart, 'runit_service[jenkins]', :immediately
 end
 ```
+
 
 For advanced users, this resource exposes an `options` attribute that will be passed to the installation command. For more information on the possible values of these options, pleaes consult the documentation for your Jenkins installation.
 

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -38,7 +38,7 @@ when 'debian'
   template '/etc/default/jenkins' do
     source   'jenkins-config-debian.erb'
     mode     '0644'
-    notifies :restart, 'runit_service[jenkins]', :immediately
+    notifies :restart, 'service[jenkins]', :immediately
   end
 when 'rhel'
   include_recipe 'yum::default'
@@ -55,7 +55,7 @@ when 'rhel'
   template '/etc/sysconfig/jenkins' do
     source   'jenkins-config-rhel.erb'
     mode     '0644'
-    notifies :restart, 'runit_service[jenkins]', :immediately
+    notifies :restart, 'service[jenkins]', :immediately
   end
 end
 

--- a/test/fixtures/cookbooks/jenkins_job/recipes/create_folder.rb
+++ b/test/fixtures/cookbooks/jenkins_job/recipes/create_folder.rb
@@ -4,7 +4,7 @@ include_recipe 'jenkins::master'
 # (some jobs like those created by the cloudbees-folder plugin do not have disabled in their XML config)
 
 jenkins_plugin 'cloudbees-folder' do
-    notifies :restart, 'runit_service[jenkins]', :immediately
+    notifies :restart, 'service[jenkins]', :immediately
 end
 
 config = File.join(Chef::Config[:file_cache_path], 'folder-config.xml')


### PR DESCRIPTION
At the 1.0 release, the runit cookbook replaced it's definition with a resource and provider that extend the built-in chef service resource. However, it provided a wrapper for users doing it the 'old way', that created a generic `service` resource that could receive notifications for backwards compat. This generic `service[jenkins]` resource, being used within the jenkins cookbook, also ignored settings passed (like the timeout setting in runit). This commit replaces all of the instances of `notifies :foo, 'service[jenkins]'` with `notifies :foo, 'runit_service[jenkins]'`. It also adds a new `sv_timeout` setting that is passed through to the `runit_service` resource to allow for users to set a longer timeout on jenkins startup (it can be slow).
