### PR TITLE
add attribute for Jenkins user system account

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -126,6 +126,15 @@ default['jenkins']['master'].tap do |master|
   master['group'] = 'jenkins'
 
   #
+  # Jenkins user/group should be created as `system` accounts for `war` install.
+  # The default of `true` will ensure that **new** jenkins user accounts are
+  # created in the system ID range, exisitng users will not be modified.
+  #
+  #   node.set['jenkins']['master']['use_system_accounts'] = false
+  #
+  master['use_system_accounts'] = true
+
+  #
   # The host the Jenkins master is running on. For single-installs, the default
   # value of +localhost+ will suffice. For multi-node installs, you will likely
   # need to update this attribute to the FQDN of your Jenkins master.

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -27,11 +27,13 @@
 # Create the Jenkins user
 user node['jenkins']['master']['user'] do
   home node['jenkins']['master']['home']
+  system node['jenkins']['master']['use_system_accounts']
 end
 
 # Create the Jenkins group
 group node['jenkins']['master']['group'] do
   members node['jenkins']['master']['user']
+  system node['jenkins']['master']['use_system_accounts']
 end
 
 # Create the home directory

--- a/spec/recipes/master_spec.rb
+++ b/spec/recipes/master_spec.rb
@@ -1,51 +1,106 @@
 require 'spec_helper'
 
 describe 'jenkins::_master_war' do
-  let(:home)          { '/opt/bacon' }
-  let(:log_directory) { '/opt/bacon/log' }
-  let(:user)          { 'bacon' }
-  let(:group)         { 'meats' }
+  context '(default) system account is false' do
+    let(:home)          { '/opt/bacon' }
+    let(:log_directory) { '/opt/bacon/log' }
+    let(:user)          { 'bacon' }
+    let(:group)         { 'meats' }
 
-  cached(:chef_run) do
-    ChefSpec::Runner.new do |node|
-      node.set['jenkins']['master']['home']           = home
-      node.set['jenkins']['master']['log_directory']  = log_directory
-      node.set['jenkins']['master']['user']           = user
-      node.set['jenkins']['master']['group']          = group
-      node.set['jenkins']['master']['install_method'] = 'war'
+    cached(:chef_run) do
+      ChefSpec::Runner.new do |node|
+        node.set['jenkins']['master']['home']           = home
+        node.set['jenkins']['master']['log_directory']  = log_directory
+        node.set['jenkins']['master']['user']           = user
+        node.set['jenkins']['master']['group']          = group
+        node.set['jenkins']['master']['install_method'] = 'war'
 
-      # Workaround until https://github.com/hw-cookbooks/runit/pull/57 is merged.
-      node.set[:runit][:sv_bin] = '/usr/bin/sv'
-    end.converge(described_recipe)
+        # Workaround until https://github.com/hw-cookbooks/runit/pull/57 is merged.
+        node.set[:runit][:sv_bin] = '/usr/bin/sv'
+      end.converge(described_recipe)
+    end
+
+    before do
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe)
+    end
+
+    it 'creates the user' do
+      expect(chef_run).to create_user(user)
+        .with_home(home)
+    end
+
+    it 'creates the group' do
+      expect(chef_run).to create_group(group)
+        .with_members([user])
+    end
+
+    it 'creates the home directory' do
+      expect(chef_run).to create_directory(home)
+        .with_owner(user)
+        .with_group(group)
+        .with_mode('0755')
+        .with_recursive(true)
+    end
+
+    it 'creates the log directory' do
+      expect(chef_run).to create_directory(log_directory)
+        .with_owner(user)
+        .with_group(group)
+        .with_mode('0755')
+        .with_recursive(true)
+    end
   end
 
-  before do
-    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe)
-  end
+  context 'system account is true' do
+    let(:home)          { '/opt/bacon' }
+    let(:log_directory) { '/opt/bacon/log' }
+    let(:user)          { 'bacon' }
+    let(:group)         { 'meats' }
 
-  it 'creates the user' do
-    expect(chef_run).to create_user(user)
-      .with_home(home)
-  end
+    cached(:chef_run) do
+      ChefSpec::Runner.new do |node|
+        node.set['jenkins']['master']['home']           = home
+        node.set['jenkins']['master']['log_directory']  = log_directory
+        node.set['jenkins']['master']['user']           = user
+        node.set['jenkins']['master']['group']          = group
+        node.set['jenkins']['master']['install_method'] = 'war'
+        node.set['jenkins']['master']['use_system_accounts'] = true
 
-  it 'creates the group' do
-    expect(chef_run).to create_group(group)
-      .with_members([user])
-  end
+        # Workaround until https://github.com/hw-cookbooks/runit/pull/57 is merged.
+        node.set[:runit][:sv_bin] = '/usr/bin/sv'
+      end.converge(described_recipe)
+    end
 
-  it 'creates the home directory' do
-    expect(chef_run).to create_directory(home)
-      .with_owner(user)
-      .with_group(group)
-      .with_mode('0755')
-      .with_recursive(true)
-  end
+    before do
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe)
+    end
 
-  it 'creates the log directory' do
-    expect(chef_run).to create_directory(log_directory)
-      .with_owner(user)
-      .with_group(group)
-      .with_mode('0755')
-      .with_recursive(true)
+    it 'creates the user' do
+      expect(chef_run).to create_user(user)
+        .with_home(home)
+        .with(system: true)
+    end
+
+    it 'creates the group' do
+      expect(chef_run).to create_group(group)
+        .with_members([user])
+        .with(system: true)
+    end
+
+    it 'creates the home directory' do
+      expect(chef_run).to create_directory(home)
+        .with_owner(user)
+        .with_group(group)
+        .with_mode('0755')
+        .with_recursive(true)
+    end
+
+    it 'creates the log directory' do
+      expect(chef_run).to create_directory(log_directory)
+        .with_owner(user)
+        .with_group(group)
+        .with_mode('0755')
+        .with_recursive(true)
+    end
   end
 end


### PR DESCRIPTION
Originally introduced in the Debian packaging system for jenkins in 2008
[1](https://issues.jenkins-ci.org/browse/JENKINS-1959), the packagers determined that the user (hudson) at the time should
be a `system` user, meaning that there are no password aging information
or home directories automatically created, as well as be created in the
SYS_UID_\* numeric range.

When introducing the `war` style installation [2](https://github.com/opscode-cookbooks/jenkins/commit/3e29e2f9e0d693b5ffa8d8a23f68440119a3c44c), the user/group are
created as the next available uid/gid in UID_MIN/GID_MIN (see
/etc/login.defs), which collides with any users created after that may
be expecting specific UIDs.

Existing systems will be unaffected, as the `user` resource does not
modify the already-created user, rather only new systems using the war
method will have their `jenkins` daemon user created as a system user,
like the package does already.

Testing note:
I wasn't sure how to best add testing for this level of branching logic in ChefSpec, after discussion on IRC, it seemed like a `context` block was the right way to go. Please let me know if that's not the desired method.
