### PR TITLE
Jenkins timeout shouldn't rescue Net::HTTP timeout

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -26,6 +26,8 @@ require 'uri'
 
 module Jenkins
   module Helper
+    class JenkinsTimeout < Timeout::Error; end
+
     class JenkinsNotReady < StandardError
       def initialize(endpoint, timeout)
         super <<-EOH
@@ -303,13 +305,14 @@ EOH
     #   if the Jenkins master does not respond within (+timeout+) seconds
     #
     def wait_until_ready!
-      Timeout.timeout(timeout) do
+      Timeout.timeout(timeout, JenkinsTimeout) do
         begin
           open(endpoint)
         rescue SocketError,
                Errno::ECONNREFUSED,
                Errno::ECONNRESET,
                Errno::ENETUNREACH,
+               Timeout::Error,
                OpenURI::HTTPError => e
           # If authentication has been enabled, the server will return an HTTP
           # 403. This is "OK", since it means that the server is actually
@@ -321,7 +324,7 @@ EOH
           retry
         end
       end
-    rescue Timeout::Error
+    rescue JenkinsTimeout
       raise JenkinsNotReady.new(endpoint, timeout)
     end
 


### PR DESCRIPTION
There is a bug in the current `timeout` functionality in the `Jenkins::Helper::wait_until_ready!` for cases where an `Net::Http` request itself hits a `Net::ReadTimeout < Timeout::Error` or `Net::OpenTimeout < Timeout::Error` (which happens when trying to access Jenkins after a restart on slow machines). The default `read_timeout` on MRI ruby is `60 seconds` so no matter what value you set `node['jenkins']['executor']['timeout']` to, it can never be longer that `60 seconds` when the URL being requested hits a low level `Net` timeout.

This fixes our `Timeout::Error` catching logic to only capture our own defined `JenkinsTimeout` and also within that given timeout block, to allow http requests to `Timeout::Error` without breaking our larger timeout block.
