### PR TITLE
enable to use hash args in execute! command

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -67,6 +67,7 @@ module Jenkins
     #   the standard out from the command
     #
     def execute!(*pieces)
+      command_options = pieces.last.is_a?(Hash) ? pieces.pop : {}
       command =  "#{Shellwords.escape(options[:java])}"
       command << " -jar #{Shellwords.escape(options[:cli])}"
       command << " -s #{URI.escape(options[:endpoint])}" if options[:endpoint]
@@ -74,7 +75,7 @@ module Jenkins
       command << " -p #{uri_escape(options[:proxy])}"    if options[:proxy]
       command << " #{pieces.join(' ')}"
 
-      command = Mixlib::ShellOut.new(command, timeout: options[:timeout])
+      command = Mixlib::ShellOut.new(command, command_options.merge(timeout: options[:timeout]))
       command.run_command
       command.error!
       command.stdout.strip

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -75,6 +75,15 @@ describe Jenkins::Executor do
       end
     end
 
+    context 'when execute! with options' do
+      let(:stdin) { "hello\nworld" }
+      it 'pass to shellout' do
+        command = 'java -jar /usr/share/jenkins/cli/java/cli.jar foo'
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60, input: stdin)
+        subject.execute!('foo', input: stdin)
+      end
+    end
+
     context 'when the command fails' do
       it 'raises an error' do
         allow(shellout).to receive(:error!).and_raise(RuntimeError)


### PR DESCRIPTION
a lot of commands are required xml file for configuration,
so users are forced to place xml file and delete it after command.

``` ruby
filename = ...

template filename do

end

jenkins_job 'foo' do
  config filename
end

file filename do
  action :delete
end
```

I think it it better to use xml string for configuration

like this

``` ruby
jenkins_job 'foo' do
  xml xml_string
end
```

and execute! will be called like this

``` ruby
executor.execute!('create-job', input: xml_string)
```

so, at first, I enable to use hash args in execute! method.
