### PR TITLE
Make sure Net::HTTP#use_ssl is turned on for https end-point

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -381,6 +381,7 @@ EOH
           'Accept' => 'application/json'
         }
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
         response = http.post(uri.path, extracted_json, headers)
 
         true


### PR DESCRIPTION
Net::HTTP default to false and cause the following error w/ https end point

```
Errno::EPIPE: jenkins_plugin[git] (blp-jenkins::master line 52) had an error: Errno::EPIPE: Broken pipe
/opt/chef/embedded/lib/ruby/1.9.1/net/protocol.rb:199:in `write'
/opt/chef/embedded/lib/ruby/1.9.1/net/protocol.rb:199:in `write0'
/opt/chef/embedded/lib/ruby/1.9.1/net/protocol.rb:173:in `block in write'
/opt/chef/embedded/lib/ruby/1.9.1/net/protocol.rb:190:in `writing'
/opt/chef/embedded/lib/ruby/1.9.1/net/protocol.rb:172:in `write'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1938:in `send_request_with_body'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1920:in `exec'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1318:in `block in transport_request'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1317:in `catch'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1317:in `transport_request'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1294:in `request'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1287:in `block in request'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:746:in `start'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1285:in `request'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1308:in `send_entity'
/opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:1097:in `post'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/_helper.rb:384:in `ensure_update_center_present!'
```
