### PR TITLE
stop downloading .war file on every run

### DIFF
--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -62,6 +62,7 @@ remote_file File.join(node['jenkins']['master']['home'], 'jenkins.war') do
   owner    node['jenkins']['master']['user']
   group    node['jenkins']['master']['group']
   notifies :restart, 'runit_service[jenkins]'
+  not_if { ::File.exists?("#{node['jenkins']['master']['home']}/jenkins.war") }
 end
 
 Chef::Log.warn('Here we go with the runit service')


### PR DESCRIPTION
This keeps from downloading the jenkins.war on every run. 
I've only tested in an Ubuntu 14.04 vagrant box.
