### PR TITLE
Use jenkins master user node attribute in jenkins-config-rhel.erb

### DIFF
--- a/templates/default/jenkins-config-rhel.erb
+++ b/templates/default/jenkins-config-rhel.erb
@@ -31,7 +31,7 @@ JENKINS_JAVA_CMD="<%= node['jenkins']['java'] %>"
 # Be careful when you change this, as you need to update
 # permissions of $JENKINS_HOME and /var/log/jenkins.
 #
-JENKINS_USER="jenkins"
+JENKINS_USER="<%= node['jenkins']['master']['user'] %>"
 
 ## Type:        string
 ## Default:     "-Djava.awt.headless=true"


### PR DESCRIPTION
Currently the jenkins-config-rhel template is hardcoded with the username 'jenkins' causing the service to fail when a user other than 'jenkins' is specified.
