### PR TITLE
Recover from commands executed against masters with auth disabled

### DIFF
--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -100,7 +100,8 @@ module Jenkins
            ((exitstatus == 1) && (stderr =~ /^Exception in thread "main" java\.io\.EOFException/))
           command.reject! { |c| c =~ /-i/ }
           retry
-        elsif (exitstatus == 255) && (stderr =~ /^"--username" is not a valid option/)
+        elsif ((exitstatus == 255) && (stderr =~ /^"--username" is not a valid option/)) ||
+              ((exitstatus == 1) && (stderr =~ /^"--username" is not a valid option/))
           command.reject! { |c| c =~ /--username|--password/ }
           retry
         end


### PR DESCRIPTION
This fixes one more case of JENKINS-22346 when using username / password auth with jenkins-cli
