### PR TITLE
Send logs to log directory instead of syslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the jenkins cookbook.
 
+## 6.0.1 (2018-04-05)
+
+- Log to /var/log/jenkins instead of syslog
+
 ## 6.0.0 (2018-02-16)
 
 - Require Chef 12.14+ and remove compat_resource dependency

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs and configures Jenkins CI master & slaves'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.0.0'
+version          '6.0.1'
 
 recipe 'jenkins::master', 'Installs a Jenkins master'
 

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -69,4 +69,8 @@ Chef::Log.warn('Here we go with the runit service')
 # Create runit service
 runit_service 'jenkins' do
   sv_timeout node['jenkins']['master']['runit']['sv_timeout']
+  options({
+    log_directory: node['jenkins']['master']['log_directory'],
+    user: node['jenkins']['master']['user'],
+  }.merge(params))
 end

--- a/templates/sv-jenkins-log-run.erb
+++ b/templates/sv-jenkins-log-run.erb
@@ -5,4 +5,4 @@
 # Do NOT modify this file by hand.
 #
 
-exec chpst -unobody logger -d -p local6.info -t [jenkins]
+exec chpst -u<%= @options[:user] %> svlogd -tt <%= @options[:log_directory] %>


### PR DESCRIPTION
### Description

Follows the more standard way of logging jenkins output to /var/log/jenkins instead of into the shared syslog

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>