### PR TITLE
Adding cli user and password options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Fix the implementation of the cli user/password authentication method - [@ddegoede](https://github.com/ddegoede)
+
 ## 8.0.4 - *2020-11-24*
 
 - Retry jenkins CLI command without authenticating after receiving an HTTP 401. - [@nuclearsandwich](https://github.com/nuclearsandwich)
@@ -22,7 +24,7 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## 8.0.0 (2020-07-14)
 
-- Fixed groovy indentation errors in the generated code
+- Fixed groovy indentation errors in the generated code - [@ddegoede](https://github.com/ddegoede)
 - Set default CLI protocol attribute to http now that remoting is deprecated in newer Jenkins releases - [@rjbaker](https://github.com/rjbaker)
 - Adding support for SSH Slaves/SSH Build Agents plugin version >= 1.30 - [@joemillerr](https://github.com/joemillerr)
 - Added attribute value for directory mode for jenkins directories

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -73,11 +73,11 @@ module Jenkins
       command << options[:jvm_options].to_s if options[:jvm_options]
       command << %(-jar "#{options[:cli]}")
       command << %(-s #{URI.escape(options[:endpoint])}) if options[:endpoint]
-      command << %(-"#{options[:protocol]}")             if options[:protocol]
+      command << %(-#{options[:protocol]})               if options[:protocol]
       command << %(-user "#{options[:cli_user]}")        if options[:cli_user]
       command << %(-i "#{options[:key]}")                if options[:key]
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]
-      command << %(-auth "#{options[:username]}":"#{options[:password]}") if options[:username] && options[:password]
+      command << %(-auth #{options[:cli_username]}:#{options[:cli_password]}) if options[:cli_username] && options[:cli_password]
       command.push(pieces)
 
       begin

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -73,6 +73,8 @@ If this problem persists, check your Jenkins log files.
         h[:jvm_options] = jvm_options unless jvm_options.nil?
         h[:protocol] = protocol unless protocol.nil?
         h[:cli_user] = cli_user unless cli_user.nil?
+        h[:cli_username] = cli_username unless cli_username.nil?
+        h[:cli_password] = cli_password unless cli_password.nil?
       end
 
       Jenkins::Executor.new(options)
@@ -379,6 +381,24 @@ If this problem persists, check your Jenkins log files.
     #
     def cli_user
       node['jenkins']['executor']['cli_user']
+    end
+
+    #
+    # cli_username to pass to cli
+    #
+    # @return [String]
+    #
+    def cli_username
+      node['jenkins']['executor']['cli_username']
+    end
+
+    #
+    # password to pass to cli
+    #
+    # @return [String]
+    #
+    def cli_password
+      node['jenkins']['executor']['cli_password']
     end
 
     #

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -52,9 +52,9 @@ describe Jenkins::Executor do
     context 'when a :cli_username option is given' do
       context 'when a :cli_password option is given' do
         it 'adds -auth option' do
-          subject.options[:username] = 'user'
-          subject.options[:password] = 'password'
-          command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" -auth "user":"password" foo)
+          subject.options[:cli_username] = 'user'
+          subject.options[:cli_password] = 'password'
+          command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" -auth user:password foo)
           expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
           subject.execute!('foo')
         end


### PR DESCRIPTION
### Description

This adds a specified user to use for basic authentication for the jenkins-cli
using a username and password, where the password is a token

Signed-off-by: Daan de Goede <ddegoede@schubergphilis.com>

### Issues Resolved

This partially fixes #599, is enables http protocol if a username and password is given. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
