### PR TITLE
jenkins_user bugfix: If user has more than one public key it tries to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Fix idempotency issue with `jenkins_user` when users have more than one public key
+
 ## 8.2.0 - *2021-02-08*
 
 - Sous Chefs Adoption

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -156,7 +156,7 @@ class Chef
         keys = null
         keysProperty = user.getProperty(org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl)
         if(keysProperty != null) {
-          keys = keysProperty.authorizedKeys.split('\\\\\\\\s+') - "" // Remove empty strings
+          keys = keysProperty.authorizedKeys.split('\\n') - "" // Remove empty strings
         }
 
         builder = new groovy.json.JsonBuilder()


### PR DESCRIPTION
… create/update the user on each run, it's not comparing publick_keys correctly to be idempotent

