### PR TITLE
Resolve https://github.com/sous-chefs/jenkins/issues/759 by removing the 'touch' command executed as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Remove touch command run as root from .war-based service definition - [@davidsainty](https://github.com/davidsainty)
+
 ## 8.0.2 (2020-09-14)
 
 - jenkins_job: Dont quote param unnecessarily - [@mbaitelman](https://github.com/mbaitelman)

--- a/templates/sv-jenkins-run.erb
+++ b/templates/sv-jenkins-run.erb
@@ -10,7 +10,6 @@
 <% groups = ([node['jenkins']['master']['user']] + node['jenkins']['master']['runit']['groups']).join(':') %>
 exec 2>&1
 cd <%= node['jenkins']['master']['home'] %>
-touch jenkins.start
 <% limits = node['jenkins']['master']['ulimits'] %>
 <% if limits && !limits.empty? %>
 ulimit <% limits.each { |option, value| %>-<%= option %> <%= value %> <% } %>


### PR DESCRIPTION
Resolve https://github.com/sous-chefs/jenkins/issues/759 by removing the 'touch' command executed as root

The WAR-based installation does a 'touch' of a file in the Jenkins
home whilst running as root. A user that has sufficient access to
Jenkins (E.g. can run a shell script from a Jenkins job) can create a
symbolic link from /var/lib/jenkins/jenkins.start to any location on
the filesystem the next time the Jenkins service is restarted / server
rebooted.

E.g. sh("rm -f /var/lib/jenkins/jenkins.start; ln -s /this-file-ends-up-created-in-root-directory /var/lib/jenkins/jenkins.start");

The risk is relatively low, but it's bound to be possible to exploit
to produce a local denial of service.

The history of this command seems to date back to this cookbook making
use of the file to drive a Jenkins restart.  That code was removed
from recipes/server.rb in commit
f9fbc2fbd0eb2c25edf4254cc78bc7cd95d455ad, making the touch command
redundant but left in-place.

# Description

Removes a security hole with no known loss of functionality

## Issues Resolved

https://github.com/sous-chefs/jenkins/issues/759

## Check List

- [ ] All tests pass. See TESTING.md for details.

This has been tested on RHEL builds using WAR based Jenkins installation.  It does prevent the root-created file in /var/lib/jenkins/jenkins.start being created, and does result in a Jenkins system that appears perfectly healthy.