### PR TITLE
allow use of `access_log` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Allow setting of `JENKINS_ENABLE_ACCESS_LOG` for Rhel based controllers - [@mbaitelman](https://github.com/mbaitelman)
+
 ## 8.2.1 - *2021-02-10*
 
 - Fix idempotency issue with `jenkins_user` when users have more than one public key

--- a/templates/jenkins-config-rhel.erb
+++ b/templates/jenkins-config-rhel.erb
@@ -120,7 +120,7 @@ JENKINS_DEBUG_LEVEL="<%= node['jenkins']['master']['debug_level'] %>"
 #
 # Whether to enable access logging or not.
 #
-JENKINS_ENABLE_ACCESS_LOG="no"
+JENKINS_ENABLE_ACCESS_LOG="<%= node['jenkins']['master']['access_log'] %>"
 
 ## Type:        integer
 ## Default:     100


### PR DESCRIPTION
Signed-off-by: mbaitelman <mendy@baitelman.com>

# Description

Allows setting of JENKINS_ENABLE_ACCESS_LOG for Rhel controllers

## Issues Resolved

Resolves #758 
## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
