### PR TITLE
add cli_credential_file option for authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - 'smoke-war-latest'
           - 'authentication-private-key'
           - 'authentication-username-password'
+          - 'authentication-credential-file'
           - 'jenkins-proxy-config'
           - 'jenkins-proxy-remove'
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Added option for jenkins-cli authentication with a credential file - [@amcappelli](https://github.com/amcappelli) and [@ddegoede](https://github.com/ddegoede)
+
 ## 9.0.0 - *2021-07-19*
 
 - Remove runit dependency

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -103,6 +103,14 @@ suites:
       - windows-2016
       - windows-2019
 
+  - name: authentication_credential_file
+    run_list:
+      - jenkins_authentication::credential_file
+    excludes:
+      - windows-2012r2
+      - windows-2016
+      - windows-2019
+
   #
   # Proxy suites
   # Cannot be tested together

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -79,6 +79,7 @@ module Jenkins
       command << %(-p #{uri_escape(options[:proxy])})    if options[:proxy]
       command << %(-auth #{options[:cli_username]}:#{options[:cli_password]}) if options[:cli_username] && options[:cli_password]
       command << %(-auth "#{options[:username]}":"#{options[:password]}") if options[:username] && options[:password]
+      command << %(-auth @#{options[:cli_credential_file]}) if options[:cli_credential_file] && File.file?(options[:cli_credential_file])
       command.push(*pieces)
 
       begin

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -76,6 +76,7 @@ If this problem persists, check your Jenkins log files.
         h[:cli_user] = cli_user unless cli_user.nil?
         h[:cli_username] = cli_username unless cli_username.nil?
         h[:cli_password] = cli_password unless cli_password.nil?
+        h[:cli_credential_file] = cli_credential_file unless cli_credential_file.nil?
       end
 
       Jenkins::Executor.new(options)
@@ -400,6 +401,16 @@ If this problem persists, check your Jenkins log files.
     #
     def cli_password
       node['jenkins']['executor']['cli_password']
+    end
+
+    # cli_credential_file to pass to cli
+    # used with the http protocol
+    # is used as an alternative for the cli_username and cli_password combination
+    #
+    # @return [String]
+    #
+    def cli_credential_file
+      node['jenkins']['executor']['cli_credential_file']
     end
 
     #

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -19,7 +19,7 @@ describe Jenkins::Executor do
     let(:shellout) { double(run_command: nil, error!: nil, stdout: '') }
     before { allow(Mixlib::ShellOut).to receive(:new).and_return(shellout) }
     before do
-      allow(File).to receive(:exist?).with('/etc/cli_cred_file').and_return(true)
+      allow(File).to receive(:file?).with('/etc/cli_cred_file').and_return(true)
     end
 
     it 'wraps the java and jar paths in quotes' do

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -18,6 +18,9 @@ describe Jenkins::Executor do
   describe '#execute!' do
     let(:shellout) { double(run_command: nil, error!: nil, stdout: '') }
     before { allow(Mixlib::ShellOut).to receive(:new).and_return(shellout) }
+    before do
+      allow(File).to receive(:exist?).with('/etc/cli_cred_file').and_return(true)
+    end
 
     it 'wraps the java and jar paths in quotes' do
       command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo)

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -61,6 +61,15 @@ describe Jenkins::Executor do
       end
     end
 
+    context 'when a :cli_credential_file option is given' do
+      it 'adds -auth option' do
+        subject.options[:cli_credential_file] = '/etc/cli_cred_file'
+        command = %("java" -jar "/usr/share/jenkins/cli/java/cli.jar" -auth @/etc/cli_cred_file foo)
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
     context 'when a :key option is given' do
       it 'builds the correct command' do
         subject.options[:key] = '/key/path.pem'

--- a/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
+++ b/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
@@ -1,0 +1,73 @@
+shadow_group = platform_family?('debian') ? 'shadow' : 'root'
+
+include_recipe 'jenkins_server_wrapper::default'
+
+#
+# Setup
+# ------------------------------
+
+# Ensure the `jenkins` can access /etc/shadow
+
+group shadow_group do
+  append true
+  members %w(jenkins)
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
+# RHEL uses 000 for /etc/shadow by default so we need to at least make it group readable
+file '/etc/shadow' do
+  mode '040'
+  notifies :restart, 'service[jenkins]', :immediately
+end if platform_family?('rhel', 'amazon')
+
+user 'vagrant' do
+  manage_home true
+  password '$6$a8wKXl8H$BWxzd2KvIgAFdZAdM5IDGCaDY8fL5DZ30GKzGyblFG8A/XSlpL1OiWrUg2BQpMvNE2gzgwUZRpBPUWHpJZstx.'
+end
+
+# Set up the auth file on the executor. You should pull the content from
+# a secret store or encrypted data bag item.
+cred_file = '/etc/cli_cred_file'
+file cred_file do
+  content 'vagrant:vagrant'
+  owner 'jenkins'
+  group 'root'
+  mode '0444'
+  action :create
+end
+node.default[:jenkins][:executor][:cli_credential_file] = cred_file
+
+
+jenkins_plugin 'pam-auth' do
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
+package 'openssh-server'
+
+# Turn on basic authentication
+jenkins_script 'setup authentication' do
+  command <<-EOH.gsub(/^ {4}/, '')
+    import jenkins.model.*
+    def instance = Jenkins.getInstance()
+
+    import hudson.security.*
+    def realm = new PAMSecurityRealm("sshd")
+    instance.setSecurityRealm(realm)
+
+    def strategy = new hudson.security.FullControlOnceLoggedInAuthorizationStrategy()
+    instance.setAuthorizationStrategy(strategy)
+
+    instance.save()
+  EOH
+end
+
+# Run some commands - this will ensure the CLI is correctly passing attributes
+jenkins_command 'clear-queue'
+
+# Install a plugin
+jenkins_plugin 'greenballs' do
+  notifies :restart, 'service[jenkins]', :immediately
+end
+
+# Try creating another user
+jenkins_user 'random-bob'

--- a/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
+++ b/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
@@ -37,7 +37,6 @@ file cred_file do
 end
 node.default[:jenkins][:executor][:cli_credential_file] = cred_file
 
-
 jenkins_plugin 'pam-auth' do
   notifies :restart, 'service[jenkins]', :immediately
 end

--- a/test/integration/authentication_credential_file/controls/authentication_credential_file.rb
+++ b/test/integration/authentication_credential_file/controls/authentication_credential_file.rb
@@ -1,0 +1,16 @@
+# copyright: 2018, The Authors
+
+title 'Jenkins Authentication Credential File'
+
+control 'jenkins_authentication_credential_file-1.0' do
+  impact 0.7
+  title 'Users and plugins are installed after setting PAM security'
+
+  describe jenkins_plugin('greenballs') do
+    it { should exist }
+  end
+
+  describe jenkins_user('random-bob') do
+    it { should exist }
+  end
+end

--- a/test/integration/authentication_credential_file/inspec.yml
+++ b/test/integration/authentication_credential_file/inspec.yml
@@ -1,0 +1,11 @@
+name: authentication_credential_file
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+  - name: jenkins_inspec
+    path: test/integration/helpers/jenkins_inspec


### PR DESCRIPTION
# Description

Allow users to load jenkins cli credentials from a file, as recommended by the Jenkins documentation - https://www.jenkins.io/doc/book/managing/cli/#http-connection-mode

## Issues Resolved

When providing the username:password directly in the cli command, credentials can unintentionally get logged and sent to Automate if the command fails.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
