### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chef-cookbooks/cookbook_engineering_team
+* @sous-chefs/maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 refactor: `Chef/Style/AttributeKeys`
+- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 convention: `Style/StringLiterals`
+- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:24 refactor: `Chef/Style/AttributeKeys`
+- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:25 convention: `Style/StringLiterals`
+
 ## 9.2.0 - *2021-08-29*
 
 - Include yum-epel cookbook on RHEL platforms for new daemonize package dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,8 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
-- resolved cookstyle error: libraries/job.rb:132:13 convention: `Style/ConditionalAssignment`
-- resolved cookstyle error: libraries/job.rb:133:13 convention: `Layout/CaseIndentation`
-- resolved cookstyle error: libraries/job.rb:134:15 convention: `Layout/IndentationWidth`
-- resolved cookstyle error: libraries/job.rb:135:13 convention: `Layout/ElseAlignment`
-- resolved cookstyle error: libraries/job.rb:136:15 convention: `Layout/IndentationWidth`
-- resolved cookstyle error: libraries/job.rb:137:15 convention: `Layout/IndentationWidth`
-- resolved cookstyle error: libraries/job.rb:138:31 convention: `Layout/ElseAlignment`
-- resolved cookstyle error: libraries/job.rb:139:31 convention: `Layout/IndentationWidth`
-- resolved cookstyle error: libraries/job.rb:140:31 warning: `Layout/EndAlignment`
-- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 refactor: `Chef/Style/AttributeKeys`
-- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 convention: `Style/StringLiterals`
-- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:24 refactor: `Chef/Style/AttributeKeys`
-- resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:25 convention: `Style/StringLiterals`
+- Standardise files with files in sous-chefs/repo-management
+- Various Cookstyle fixes
 
 ## 9.2.0 - *2021-08-29*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: libraries/job.rb:132:13 convention: `Style/ConditionalAssignment`
+- resolved cookstyle error: libraries/job.rb:133:13 convention: `Layout/CaseIndentation`
+- resolved cookstyle error: libraries/job.rb:134:15 convention: `Layout/IndentationWidth`
+- resolved cookstyle error: libraries/job.rb:135:13 convention: `Layout/ElseAlignment`
+- resolved cookstyle error: libraries/job.rb:136:15 convention: `Layout/IndentationWidth`
+- resolved cookstyle error: libraries/job.rb:137:15 convention: `Layout/IndentationWidth`
+- resolved cookstyle error: libraries/job.rb:138:31 convention: `Layout/ElseAlignment`
+- resolved cookstyle error: libraries/job.rb:139:31 convention: `Layout/IndentationWidth`
+- resolved cookstyle error: libraries/job.rb:140:31 warning: `Layout/EndAlignment`
 - resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 refactor: `Chef/Style/AttributeKeys`
 - resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:14 convention: `Style/StringLiterals`
 - resolved cookstyle error: test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb:38:24 refactor: `Chef/Style/AttributeKeys`

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -129,16 +129,16 @@ job must first exist on the Jenkins master!
           end
 
           new_resource.parameters.each_pair do |key, value|
-            case value
-            when TrueClass, FalseClass
-              command_args << "-p #{key}=#{value}"
-            else
-              command_args << if value.include?(' ')
+            command_args << case value
+                            when TrueClass, FalseClass
+                              "-p #{key}=#{value}"
+                            else
+                              if value.include?(' ')
                                 "-p #{key}='#{value}'"
                               else
                                 "-p #{key}=#{value}"
                               end
-            end
+                            end
           end
 
           if new_resource.stream_job_output && new_resource.wait_for_completion && stdout_stream

--- a/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
+++ b/test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb
@@ -35,7 +35,7 @@ file cred_file do
   mode '0444'
   action :create
 end
-node.default[:jenkins][:executor][:cli_credential_file] = cred_file
+node.default['jenkins']['executor'][:cli_credential_file] = cred_file
 
 jenkins_plugin 'pam-auth' do
   notifies :restart, 'service[jenkins]', :immediately


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.16.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with test/fixtures/cookbooks/jenkins_authentication/recipes/credential_file.rb

 - 38:14 refactor: `Chef/Style/AttributeKeys` - Use strings to access node attributes (https://docs.chef.io/workstation/cookstyle/chef_style_attributekeys)
 - 38:14 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 38:24 refactor: `Chef/Style/AttributeKeys` - Use strings to access node attributes (https://docs.chef.io/workstation/cookstyle/chef_style_attributekeys)
 - 38:25 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)