### PR TITLE
Pin the Jenkins version to the last pre-systemd version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 ## Unreleased
 
+- Pin the last version of Jenkins LTS which uses sysvinit scripts that this cookbook expects.
+
 ## 9.5.4 - *2022-12-08*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 9.5.3 - *2022-12-02*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 9.5.2 - *2022-03-28*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the jenkins cookbook.
 ## Unreleased
 
 - Pin the last version of Jenkins LTS which uses sysvinit scripts that this cookbook expects.
+- Use Chef 17 or lower due to multiple issues
 
 ## 9.5.4 - *2022-12-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,11 @@ This file is used to list changes made in each version of the jenkins cookbook.
 ### Breaking Changes / Deprecations
 
 - `jenkins_jnlp_slave`:
-  - Renamed `runit_groups` property to `service_groups`
-  - New service created -- old Runit service will need manual cleanup
+   - Renamed `runit_groups` property to `service_groups`
+   - New service created -- old Runit service will need manual cleanup
 
 - `jenkins::_master_war`:
-  - New service created -- old Runit service will need manual cleanup
+   - New service created -- old Runit service will need manual cleanup
 
 ## 8.2.3 - *2021-03-25*
 
@@ -519,23 +519,22 @@ This file is used to list changes made in each version of the jenkins cookbook.
 - Move testing instructions into contribution guidelines
 - Remove old TODO file
 - Refactor attributes into semantic groupings and namespaces
-
-  - `jenkins.cli` has been removed
-  - `jenkins.java_home` has been changed to `jenkins.java` and accepts the full path to the java binary, not the JAVA_HOME
-  - `jenkins.iptables_allow` has been removed
-  - `jenkins.mirror` -> `jenkins.master.mirror`
-  - `jenkins.executor` created
-  - `jenkins.executor.timeout` created
-  - `jenkins.executor.private_key` created
-  - `jenkins.executor.proxy` created
-  - `jenkins.master` created and only refers to the Jenkins master installation
-  - `jenkins.master.source` created to refer to the full URL of the war download
-  - `jenkins.master.jvm_options` created
-  - `jenkins.master.jenkins_args` added
-  - `jenkins.master.url` -> `jenkins.master.endpoint`
-  - `jenkins.master.log_directory` created
-  - `jenkins.node` attributes have all been removed
-  - `jenkins.server` attributes have all been removed
+   - `jenkins.cli` has been removed
+   - `jenkins.java_home` has been changed to `jenkins.java` and accepts the full path to the java binary, not the JAVA_HOME
+   - `jenkins.iptables_allow` has been removed
+   - `jenkins.mirror` -> `jenkins.master.mirror`
+   - `jenkins.executor` created
+   - `jenkins.executor.timeout` created
+   - `jenkins.executor.private_key` created
+   - `jenkins.executor.proxy` created
+   - `jenkins.master` created and only refers to the Jenkins master installation
+   - `jenkins.master.source` created to refer to the full URL of the war download
+   - `jenkins.master.jvm_options` created
+   - `jenkins.master.jenkins_args` added
+   - `jenkins.master.url` -> `jenkins.master.endpoint`
+   - `jenkins.master.log_directory` created
+   - `jenkins.node` attributes have all been removed
+   - `jenkins.server` attributes have all been removed
 
 - Removed Chef MiniTest handler
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Platforms
 
-- Debian 9+
+- Debian 10+
 - Ubuntu 18.04+
 - RHEL/CentOS 7+
 
 ### Chef
 
-- Chef 13.0+
+- Chef 13.0+, < 18.0
 
 #### Java cookbook
 

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -39,7 +39,8 @@ default['jenkins']['master'].tap do |master|
   # package version (from the yum or apt repo), or the version of the war
   # file to download from the Jenkins mirror.
   #
-  master['version'] = nil
+  # The current default is the last version of Jenkins which uses sysvinit scripts instead of systemd units.
+  master['version'] = 2.319.3
 
   #
   # The "channel" to use, default is stable

--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -40,7 +40,7 @@ default['jenkins']['master'].tap do |master|
   # file to download from the Jenkins mirror.
   #
   # The current default is the last version of Jenkins which uses sysvinit scripts instead of systemd units.
-  master['version'] = 2.319.3
+  master['version'] = '2.319.3'
 
   #
   # The "channel" to use, default is stable

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true  # because Docker and SystemD
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
   env: [CHEF_LICENSE=accept]
   ## Uncomment to allow access to the Jenkins webui which is useful when troubleshooting
   # ports:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,5 +1,6 @@
 driver:
   name: vagrant
+  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
   customize:
     cpus: 2
     memory: 1024

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures Jenkins CI master & slaves'
 version           '9.5.4'
 source_url        'https://github.com/sous-chefs/jenkins'
 issues_url        'https://github.com/sous-chefs/jenkins/issues'
-chef_version      '>= 13.0'
+chef_version      '>= 13.0', '< 18.0'
 
 supports 'amazon'
 supports 'centos'

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -51,6 +51,11 @@ package 'jenkins' do
   version node['jenkins']['master']['version']
 end
 
+service 'jenkins' do
+  supports status: true, restart: true, reload: true
+  action [:enable, :start]
+end
+
 directory node['jenkins']['master']['home'] do
   owner     node['jenkins']['master']['user']
   group     node['jenkins']['master']['group']
@@ -90,9 +95,4 @@ when 'rhel', 'amazon'
     mode     '0644'
     notifies :restart, 'service[jenkins]', :immediately
   end
-end
-
-service 'jenkins' do
-  supports status: true, restart: true, reload: true
-  action [:enable, :start]
 end


### PR DESCRIPTION
# Description

This cookbook expects the package install of Jenkins to install with sysvinit style init scripts and configures jenkins with that assumption.

Jenkins packages after 2.335 (weekly) and 2.332.1 (LTS) and on use systemd service units to manage the Jenkins service [[1]].

This cookbook has not yet been made compatible with these versions.

This pull request is something of a straw man to get CI turning over again so I can start working on a new cookbook version that supports the current Jenkins packages.

[1]: https://www.jenkins.io/blog/2022/03/25/systemd-migration/

Describe what this change achieves

## Issues Resolved

In the large this doesn't really resolve anything as it forces cookbook consumers to use an older version of Jenkins, I'm not entirely certain if I would recommend that this PR be merged. It depends on whether being stuck on an older version is worse than being completely non-functional in the eyes of other cookbook maintainers.

https://github.com/sous-chefs/jenkins/issues/783 and https://github.com/sous-chefs/jenkins/issues/789 are both related to these upstream changes.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
