### PR TITLE
Fix for [JENKINS-72181] -- Jenkins-cli groovy command does not return stdout and stderr (regression in 2.427)

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -199,6 +199,7 @@ class Chef
 
         builder = new groovy.json.JsonBuilder(output)
         println(builder)
+        out.flush()
       EOH
       output = JSON.parse(json, symbolize_names: true)
       @jnlp_secret = output[:secret]


### PR DESCRIPTION
# Description

In order to fix [JENKINS-72181](https://issues.jenkins.io/browse/JENKINS-72181), introduced in Jenkins version 2.427, we will have to add `out.flush()` so that the cookbook can print & get the slave jnlp secret correctly.

## Issues Resolved
With the latest Jenkins version 2.427 onwards, jenkins-cli groovy command does not return stdout and stderr. So cookbook was not able to get the slave jnlp secret correctly and was not able to register with the master.

This change should fix the issue.

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
