### PR TITLE
jenkins_slave_jnlp resource creation is not compatible with Ruby3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the jenkins cookbook.
 
 - Create `jenkins_githubapp_credentials` resource for creating and managing GitHub app Jenkins credentials
 - Fix `jenkins_slave_jnlp` by evaluating `slave_jar_url` correctly
+- Remove runit services before starting new service
 
 ## 9.5.23 - *2024-11-18*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the jenkins cookbook.
 ## Unreleased
 
 - Create `jenkins_githubapp_credentials` resource for creating and managing GitHub app Jenkins credentials
+- Fix `jenkins_slave_jnlp` by evaluating `slave_jar_url` correctly
 
 ## 9.5.23 - *2024-11-18*
 

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -85,39 +85,18 @@ class Chef
         action :create
       end
 
-      declare_resource(:remote_file, slave_jar).tap do |r|
-        # We need to use .tap() to access methods in the provider's scope.
-        r.source slave_jar_url
-        r.backup(false)
-        r.mode('0755')
-        r.atomic_update(false)
-        r.notifies :restart, "systemd_unit[#{new_resource.service_name}.service]" unless platform?('windows')
+      u = slave_jar_url
+      declare_resource(:remote_file, slave_jar) do
+        source(u)
+        backup(false)
+        mode('0755')
+        atomic_update(false)
+        notifies :restart, "systemd_unit[#{new_resource.service_name}.service]" unless platform?('windows')
       end
 
       # The Windows's specific child class manages it's own service
       return if platform?('windows')
 
-      # disable runit services before starting new service
-      # TODO: remove in future version
-
-      %W(
-        /etc/init.d/#{new_resource.service_name}
-        /etc/service/#{new_resource.service_name}
-      ).each do |f|
-        file f do
-          action :delete
-          notifies :stop, "service[#{new_resource.service_name}]", :before
-        end
-      end
-
-      # runit_service = if platform_family?('debian')
-      #                   'runit'
-      #                 else
-      #                   'runsvdir-start'
-      #                 end
-      # service runit_service do
-      #   action [:stop, :disable]
-      # end
 
       exec_string = "#{java} #{new_resource.jvm_options}"
       exec_string << " -jar #{slave_jar}" if slave_jar


### PR DESCRIPTION
# Description

1. jenkins_slave_jnlp breaks recipe run when executed on cinc-18 client (Ruby3.1).
slave_jar_url method is not executed and remote_resource has no source defined.

To fix it, I just moved slave_jar_url evaluation outside the resource declaration scope.

2. file actions notify undefined service name, this breaks recipe execution.
removed  runit services before starting new service

## Issues Resolved

https://github.com/sous-chefs/jenkins/pull/813

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
