### PR TITLE
fix: share Jenkins current value helpers

### DIFF
--- a/libraries/agent_helpers.rb
+++ b/libraries/agent_helpers.rb
@@ -1,0 +1,84 @@
+#
+# Cookbook:: jenkins
+# Library:: agent_helpers
+#
+
+require_relative '_helper'
+
+module Jenkins
+  module AgentHelpers
+    include Jenkins::Helper
+
+    def attribute_to_property_map
+      {}
+    end
+
+    def current_slave_from_jenkins(resource = agent_resource)
+      return @current_slave if @current_slave
+
+      Chef::Log.debug "Load #{resource} agent information"
+
+      launcher_attributes = []
+      attribute_to_property_map.each_pair do |resource_attribute, groovy_property|
+        launcher_attributes << "current_slave['#{resource_attribute}'] = #{groovy_property}"
+      end
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import hudson.model.*
+        import hudson.slaves.*
+        import jenkins.model.*
+        import jenkins.slaves.*
+
+        slave = Jenkins.instance.getNode('#{resource.slave_name}') as Slave
+
+        if(slave == null) {
+          return null
+        }
+
+        def slave_environment = null
+        slave_env_vars = slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars
+        if (slave_env_vars)
+          slave_environment = new java.util.HashMap<String,String>(slave_env_vars)
+
+        current_slave = [
+          name:slave.name,
+          description:slave.nodeDescription,
+          remote_fs:slave.remoteFS,
+          executors:slave.numExecutors.toInteger(),
+          usage_mode:slave.mode.toString().toLowerCase(),
+          labels:slave.labelString.split().sort(),
+          environment:slave_environment,
+          connected:(slave.computer.connectTime > 0),
+          online:slave.computer.online
+        ]
+
+        if (slave.retentionStrategy instanceof RetentionStrategy.Always) {
+          current_slave['availability'] = 'always'
+        } else if (slave.retentionStrategy instanceof RetentionStrategy.Demand) {
+          current_slave['availability'] = 'demand'
+          retention = slave.retentionStrategy as RetentionStrategy.Demand
+          current_slave['in_demand_delay'] = retention.inDemandDelay
+          current_slave['idle_delay'] = retention.idleDelay
+        } else {
+          current_slave['availability'] = null
+        }
+
+        #{launcher_attributes.join("\n")}
+
+        builder = new groovy.json.JsonBuilder(current_slave)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_slave = JSON.parse(json, symbolize_names: true)
+      @current_slave = convert_blank_values_to_nil(@current_slave)
+    end
+
+    private
+
+    def agent_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/file_credentials_helpers.rb
+++ b/libraries/file_credentials_helpers.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook:: jenkins
+# Library:: file_credentials_helpers
+#
+
+require_relative '_helper'
+require_relative 'credentials_helpers'
+
+module Jenkins
+  module FileCredentialsHelpers
+    include Jenkins::Helper
+    include Jenkins::CredentialsHelpers
+
+    def current_credentials_from_jenkins(resource = credentials_resource)
+      return @current_credentials if @current_credentials
+
+      Chef::Log.debug "Load #{resource} credentials information"
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import org.jenkinsci.plugins.plaincredentials.impl.*;
+
+        #{credentials_for_id_groovy(resource.id, 'credentials')}
+
+        if(credentials == null) {
+          return null
+        }
+
+        current_credentials = [
+          id:credentials.id,
+          description:credentials.description,
+          filename:credentials.filename
+        ]
+
+        builder = new groovy.json.JsonBuilder(current_credentials)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_credentials = JSON.parse(json, symbolize_names: true)
+      @current_credentials = convert_blank_values_to_nil(@current_credentials)
+    end
+
+    private
+
+    def credentials_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/githubapp_credentials_helpers.rb
+++ b/libraries/githubapp_credentials_helpers.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: jenkins
+# Library:: githubapp_credentials_helpers
+#
+
+require_relative '_helper'
+require_relative 'credentials_helpers'
+
+module Jenkins
+  module GitHubAppCredentialsHelpers
+    include Jenkins::Helper
+    include Jenkins::CredentialsHelpers
+
+    def current_credentials_from_jenkins(resource = credentials_resource)
+      return @current_credentials if @current_credentials
+
+      Chef::Log.debug "Load #{resource} credentials information"
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import org.jenkinsci.plugins.github_branch_source.*;
+
+        #{credentials_for_id_groovy(resource.id, 'credentials')}
+
+        if(credentials == null) {
+          return null
+        }
+
+        current_credentials = [
+          id:credentials.id,
+          description:credentials.description,
+          app_id:credentials.username
+        ]
+
+        current_credentials['private_key_pkcs8_pem'] = credentials.privateKey.plainText
+
+        builder = new groovy.json.JsonBuilder(current_credentials)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_credentials = JSON.parse(json, symbolize_names: true)
+      @current_credentials = convert_blank_values_to_nil(@current_credentials)
+    end
+
+    private
+
+    def credentials_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/password_credentials_helpers.rb
+++ b/libraries/password_credentials_helpers.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: jenkins
+# Library:: password_credentials_helpers
+#
+
+require_relative '_helper'
+require_relative 'credentials_helpers'
+
+module Jenkins
+  module PasswordCredentialsHelpers
+    include Jenkins::Helper
+    include Jenkins::CredentialsHelpers
+
+    def current_credentials_from_jenkins(resource = credentials_resource)
+      return @current_credentials if @current_credentials
+
+      Chef::Log.debug "Load #{resource} credentials information"
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import com.cloudbees.plugins.credentials.impl.*;
+
+        #{credentials_for_id_groovy(resource.id, 'credentials')}
+
+        if(credentials == null) {
+          return null
+        }
+
+        current_credentials = [
+          id:credentials.id,
+          description:credentials.description,
+          username:credentials.username
+        ]
+
+        current_credentials['password'] = credentials.password.plainText
+
+        builder = new groovy.json.JsonBuilder(current_credentials)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_credentials = JSON.parse(json, symbolize_names: true)
+      @current_credentials = convert_blank_values_to_nil(@current_credentials)
+    end
+
+    private
+
+    def credentials_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/private_key_credentials_helpers.rb
+++ b/libraries/private_key_credentials_helpers.rb
@@ -1,0 +1,84 @@
+#
+# Cookbook:: jenkins
+# Library:: private_key_credentials_helpers
+#
+
+require_relative '_helper'
+require_relative 'credentials_helpers'
+
+module Jenkins
+  module PrivateKeyCredentialsHelpers
+    include Jenkins::Helper
+    include Jenkins::CredentialsHelpers
+
+    #
+    # Determine whether a key is an ECDSA key.
+    #
+    def ecdsa_key?(key)
+      key.include?('BEGIN EC PRIVATE KEY')
+    end
+
+    #
+    # Private key in PEM format
+    #
+    def pem_private_key
+      resource = credentials_resource
+
+      if resource.private_key.is_a?(OpenSSL::PKey::RSA) || resource.private_key.is_a?(OpenSSL::PKey::EC)
+        resource.private_key.to_pem
+      elsif ecdsa_key?(resource.private_key)
+        OpenSSL::PKey::EC.new(resource.private_key).to_pem
+      else
+        OpenSSL::PKey::RSA.new(resource.private_key).to_pem
+      end
+    end
+
+    def current_credentials_from_jenkins(resource = credentials_resource)
+      return @current_credentials if @current_credentials
+
+      Chef::Log.debug "Load #{resource} credentials information"
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import com.cloudbees.jenkins.plugins.sshcredentials.impl.*;
+
+        #{credentials_for_id_groovy(resource.id, 'credentials')}
+
+        if(credentials == null) {
+          return null
+        }
+
+        current_credentials = [
+          id:credentials.id,
+          description:credentials.description,
+          username:credentials.username
+        ]
+
+        current_credentials['private_key'] = credentials.privateKey
+        current_credentials['passphrase'] = credentials.passphrase && credentials.passphrase.plainText
+
+        builder = new groovy.json.JsonBuilder(current_credentials)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_credentials = JSON.parse(json, symbolize_names: true)
+      @current_credentials = convert_blank_values_to_nil(@current_credentials)
+
+      # Normalize the private key
+      if @current_credentials && @current_credentials[:private_key]
+        cc = @current_credentials[:private_key]
+        cc = @current_credentials[:private_key].to_pem unless cc.is_a?(String)
+        @current_credentials[:private_key] = ecdsa_key?(cc) ? OpenSSL::PKey::EC.new(cc) : OpenSSL::PKey::RSA.new(cc)
+      end
+
+      @current_credentials
+    end
+
+    private
+
+    def credentials_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/proxy_helpers.rb
+++ b/libraries/proxy_helpers.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook:: jenkins
+# Library:: proxy_helpers
+#
+
+require_relative '_helper'
+
+module Jenkins
+  module ProxyHelpers
+    include Jenkins::Helper
+
+    #
+    # Loads the local proxy into a hash
+    #
+    def current_proxy_from_jenkins(resource = proxy_resource)
+      return @current_proxy if @current_proxy
+
+      Chef::Log.debug "Load #{resource} proxy information"
+
+      json = executor.groovy <<-EOH.gsub(/^ {6}/, '')
+        import java.util.Collections
+        import java.util.List
+
+        import jenkins.model.Jenkins
+        def instance = Jenkins.getInstance()
+
+        def pc = instance.proxy
+        if (pc == null) {
+          return null
+        }
+
+        def no_proxy = pc.noProxyHost
+        if (no_proxy != null) {
+          no_proxy = no_proxy.tokenize('[ \\t\\n,|]+')
+        } else {
+          no_proxy = Collections.emptyList()
+        }
+
+        def builder = new groovy.json.JsonBuilder()
+        builder {
+          proxy pc.name + ':' + pc.port.toString()
+          noproxy no_proxy
+        }
+
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_proxy = JSON.parse(json, symbolize_names: true)
+      @current_proxy
+    end
+
+    private
+
+    def proxy_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/secret_text_credentials_helpers.rb
+++ b/libraries/secret_text_credentials_helpers.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: jenkins
+# Library:: secret_text_credentials_helpers
+#
+
+require_relative '_helper'
+require_relative 'credentials_helpers'
+
+module Jenkins
+  module SecretTextCredentialsHelpers
+    include Jenkins::Helper
+    include Jenkins::CredentialsHelpers
+
+    def current_credentials_from_jenkins(resource = credentials_resource)
+      return @current_credentials if @current_credentials
+
+      Chef::Log.debug "Load #{resource} credentials information"
+
+      json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
+        import org.jenkinsci.plugins.plaincredentials.impl.*;
+
+        #{credentials_for_id_groovy(resource.id, 'credentials')}
+
+        if(credentials == null) {
+          return null
+        }
+
+        current_credentials = [
+          id:credentials.id,
+          description:credentials.description,
+          secret:credentials.secret
+        ]
+
+        current_credentials['secret'] = credentials.secret.plainText
+
+        builder = new groovy.json.JsonBuilder(current_credentials)
+        println(builder)
+      EOH
+
+      return if json.nil? || json.empty?
+
+      @current_credentials = JSON.parse(json, symbolize_names: true)
+      @current_credentials = convert_blank_values_to_nil(@current_credentials)
+    end
+
+    private
+
+    def credentials_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/libraries/ssh_agent_helpers.rb
+++ b/libraries/ssh_agent_helpers.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook:: jenkins
+# Library:: ssh_agent_helpers
+#
+
+require_relative 'agent_helpers'
+
+module Jenkins
+  module SshAgentHelpers
+    include Jenkins::AgentHelpers
+
+    def attribute_to_property_map
+      {
+        host: 'launcher.host',
+        port: 'launcher.port',
+        credentials: 'launcher.credentialsId',
+      }
+    end
+  end
+end

--- a/libraries/view_helpers.rb
+++ b/libraries/view_helpers.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook:: jenkins
+# Library:: view_helpers
+#
+
+require_relative '_helper'
+
+module Jenkins
+  module ViewHelpers
+    include Jenkins::Helper
+
+    #
+    # The view in a hash format
+    #
+    # @return [Hash]
+    #   Empty hash if the job does not exist, or a hash of important information
+    #   if it does
+    #
+    def current_view_from_jenkins(resource = view_resource)
+      return @current_view if @current_view
+
+      Chef::Log.debug "Load #{resource} view information"
+
+      get_view_as_json =
+        <<-GROOVY
+          import hudson.model.*
+          import jenkins.model.*
+          view_name = '#{resource.name}'
+          jenkins = Jenkins.instance
+
+          def view_variables = new groovy.json.JsonBuilder()
+          view_variables {}
+
+          // Output view as JSON, easily parse-able by ruby
+          view = jenkins.getView(view_name)
+          if (view) {
+            view_variables {
+              name view_name
+              jobs view.getItems().collect { it.name }
+            }
+          }
+
+          println view_variables.toString()
+        GROOVY
+
+      response = executor.groovy!(get_view_as_json)
+      return if response.nil?
+
+      Chef::Log.debug "Parse #{resource} as JSON"
+      @current_view = JSON.parse(response, object_class: Mash)
+      @current_view
+    end
+
+    private
+
+    def view_resource
+      respond_to?(:new_resource) && new_resource ? new_resource : self
+    end
+  end
+end

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -7,9 +7,10 @@ provides :jenkins_agent
 provides :jenkins_slave # Backwards compatibility alias
 
 use '_partial/_agent'
+include Jenkins::AgentHelpers
 
-load_current_value do
-  current_slave_data = current_slave_from_jenkins
+load_current_value do |new_resource|
+  current_slave_data = current_slave_from_jenkins(new_resource)
 
   if current_slave_data
     slave_name current_slave_data[:name]
@@ -78,7 +79,7 @@ action :offline do
 end
 
 action_class do
-  include Jenkins::Helper
+  include Jenkins::AgentHelpers
 
   def exists?
     !@exists.nil? && @exists
@@ -188,69 +189,6 @@ action_class do
 
   def attribute_to_property_map
     {}
-  end
-
-  def current_slave_from_jenkins
-    return @current_slave if @current_slave
-
-    Chef::Log.debug "Load #{new_resource} agent information"
-
-    launcher_attributes = []
-    attribute_to_property_map.each_pair do |resource_attribute, groovy_property|
-      launcher_attributes << "current_slave['#{resource_attribute}'] = #{groovy_property}"
-    end
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import hudson.model.*
-      import hudson.slaves.*
-      import jenkins.model.*
-      import jenkins.slaves.*
-
-      slave = Jenkins.instance.getNode('#{new_resource.slave_name}') as Slave
-
-      if(slave == null) {
-        return null
-      }
-
-      def slave_environment = null
-      slave_env_vars = slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars
-      if (slave_env_vars)
-        slave_environment = new java.util.HashMap<String,String>(slave_env_vars)
-
-      current_slave = [
-        name:slave.name,
-        description:slave.nodeDescription,
-        remote_fs:slave.remoteFS,
-        executors:slave.numExecutors.toInteger(),
-        usage_mode:slave.mode.toString().toLowerCase(),
-        labels:slave.labelString.split().sort(),
-        environment:slave_environment,
-        connected:(slave.computer.connectTime > 0),
-        online:slave.computer.online
-      ]
-
-      // Determine retention strategy
-      if (slave.retentionStrategy instanceof RetentionStrategy.Always) {
-        current_slave['availability'] = 'always'
-      } else if (slave.retentionStrategy instanceof RetentionStrategy.Demand) {
-        current_slave['availability'] = 'demand'
-        retention = slave.retentionStrategy as RetentionStrategy.Demand
-        current_slave['in_demand_delay'] = retention.inDemandDelay
-        current_slave['idle_delay'] = retention.idleDelay
-      } else {
-        current_slave['availability'] = null
-      }
-
-      #{launcher_attributes.join("\n")}
-
-      builder = new groovy.json.JsonBuilder(current_slave)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_slave = JSON.parse(json, symbolize_names: true)
-    @current_slave = convert_blank_values_to_nil(@current_slave)
   end
 
   def correct_config?

--- a/resources/file_credentials.rb
+++ b/resources/file_credentials.rb
@@ -5,6 +5,8 @@ unified_mode true
 resource_name :jenkins_file_credentials
 provides :jenkins_file_credentials
 
+include Jenkins::FileCredentialsHelpers
+
 property :id, String, required: true
 property :filename, String, name_property: true
 property :data, String, required: true, sensitive: true
@@ -17,8 +19,8 @@ def initialize(name, run_context = nil)
   @sensitive = true
 end
 
-load_current_value do
-  current_creds = current_credentials_from_jenkins
+load_current_value do |new_resource|
+  current_creds = current_credentials_from_jenkins(new_resource)
 
   if current_creds
     id current_creds[:id]
@@ -99,38 +101,7 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-  include Jenkins::CredentialsHelpers
-
-  def current_credentials_from_jenkins
-    return @current_credentials if @current_credentials
-
-    Chef::Log.debug "Load #{new_resource} credentials information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import org.jenkinsci.plugins.plaincredentials.impl.*;
-
-      #{credentials_for_id_groovy(new_resource.id, 'credentials')}
-
-      if(credentials == null) {
-        return null
-      }
-
-      current_credentials = [
-        id:credentials.id,
-        description:credentials.description,
-        filename:credentials.filename
-      ]
-
-      builder = new groovy.json.JsonBuilder(current_credentials)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_credentials = JSON.parse(json, symbolize_names: true)
-    @current_credentials = convert_blank_values_to_nil(@current_credentials)
-  end
+  include Jenkins::FileCredentialsHelpers
 
   def correct_config?
     wanted_credentials = {

--- a/resources/githubapp_credentials.rb
+++ b/resources/githubapp_credentials.rb
@@ -5,6 +5,8 @@ unified_mode true
 resource_name :jenkins_githubapp_credentials
 provides :jenkins_githubapp_credentials
 
+include Jenkins::GitHubAppCredentialsHelpers
+
 property :id, String, required: true
 property :app_id, String, name_property: true
 property :private_key_pkcs8_pem, String, required: true, sensitive: true
@@ -18,8 +20,8 @@ def initialize(name, run_context = nil)
   @sensitive = true
 end
 
-load_current_value do
-  current_creds = current_credentials_from_jenkins
+load_current_value do |new_resource|
+  current_creds = current_credentials_from_jenkins(new_resource)
 
   if current_creds
     id current_creds[:id]
@@ -110,40 +112,7 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-  include Jenkins::CredentialsHelpers
-
-  def current_credentials_from_jenkins
-    return @current_credentials if @current_credentials
-
-    Chef::Log.debug "Load #{new_resource} credentials information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import org.jenkinsci.plugins.github_branch_source.*;
-
-      #{credentials_for_id_groovy(new_resource.id, 'credentials')}
-
-      if(credentials == null) {
-        return null
-      }
-
-      current_credentials = [
-        id:credentials.id,
-        description:credentials.description,
-        app_id:credentials.username
-      ]
-
-      current_credentials['private_key_pkcs8_pem'] = credentials.privateKey.plainText
-
-      builder = new groovy.json.JsonBuilder(current_credentials)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_credentials = JSON.parse(json, symbolize_names: true)
-    @current_credentials = convert_blank_values_to_nil(@current_credentials)
-  end
+  include Jenkins::GitHubAppCredentialsHelpers
 
   def correct_config?
     wanted_credentials = {

--- a/resources/jnlp_agent.rb
+++ b/resources/jnlp_agent.rb
@@ -7,6 +7,7 @@ provides :jenkins_jnlp_agent
 provides :jenkins_jnlp_slave # Backwards compatibility alias
 
 use '_partial/_agent'
+include Jenkins::AgentHelpers
 
 # JNLP-specific properties
 property :group, String, default: 'jenkins',
@@ -19,8 +20,8 @@ property :use_system_accounts, [true, false], default: true
 deprecated_property_alias 'runit_groups', 'service_groups',
   '`runit_groups` was renamed to `service_groups` with the move to systemd services'
 
-load_current_value do
-  current_slave_data = current_slave_from_jenkins
+load_current_value do |new_resource|
+  current_slave_data = current_slave_from_jenkins(new_resource)
 
   if current_slave_data
     slave_name current_slave_data[:name]
@@ -117,7 +118,7 @@ action :offline do
 end
 
 action_class do
-  include Jenkins::Helper
+  include Jenkins::AgentHelpers
 
   def exists?
     !@exists.nil? && @exists
@@ -211,61 +212,6 @@ action_class do
     else
       Chef::Log.debug("#{new_resource} does not exist - skipping")
     end
-  end
-
-  def current_slave_from_jenkins
-    return @current_slave if @current_slave
-
-    Chef::Log.debug "Load #{new_resource} agent information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import hudson.model.*
-      import hudson.slaves.*
-      import jenkins.model.*
-      import jenkins.slaves.*
-
-      slave = Jenkins.instance.getNode('#{new_resource.slave_name}') as Slave
-
-      if(slave == null) {
-        return null
-      }
-
-      def slave_environment = null
-      slave_env_vars = slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars
-      if (slave_env_vars)
-        slave_environment = new java.util.HashMap<String,String>(slave_env_vars)
-
-      current_slave = [
-        name:slave.name,
-        description:slave.nodeDescription,
-        remote_fs:slave.remoteFS,
-        executors:slave.numExecutors.toInteger(),
-        usage_mode:slave.mode.toString().toLowerCase(),
-        labels:slave.labelString.split().sort(),
-        environment:slave_environment,
-        connected:(slave.computer.connectTime > 0),
-        online:slave.computer.online
-      ]
-
-      if (slave.retentionStrategy instanceof RetentionStrategy.Always) {
-        current_slave['availability'] = 'always'
-      } else if (slave.retentionStrategy instanceof RetentionStrategy.Demand) {
-        current_slave['availability'] = 'demand'
-        retention = slave.retentionStrategy as RetentionStrategy.Demand
-        current_slave['in_demand_delay'] = retention.inDemandDelay
-        current_slave['idle_delay'] = retention.idleDelay
-      } else {
-        current_slave['availability'] = null
-      }
-
-      builder = new groovy.json.JsonBuilder(current_slave)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_slave = JSON.parse(json, symbolize_names: true)
-    @current_slave = convert_blank_values_to_nil(@current_slave)
   end
 
   def correct_config?

--- a/resources/password_credentials.rb
+++ b/resources/password_credentials.rb
@@ -5,6 +5,8 @@ unified_mode true
 resource_name :jenkins_password_credentials
 provides :jenkins_password_credentials
 
+include Jenkins::PasswordCredentialsHelpers
+
 property :id, String, required: true
 property :username, String, name_property: true
 property :password, String, required: true, sensitive: true
@@ -17,8 +19,8 @@ def initialize(name, run_context = nil)
   @sensitive = true
 end
 
-load_current_value do
-  current_creds = current_credentials_from_jenkins
+load_current_value do |new_resource|
+  current_creds = current_credentials_from_jenkins(new_resource)
 
   if current_creds
     id current_creds[:id]
@@ -100,40 +102,7 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-  include Jenkins::CredentialsHelpers
-
-  def current_credentials_from_jenkins
-    return @current_credentials if @current_credentials
-
-    Chef::Log.debug "Load #{new_resource} credentials information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import com.cloudbees.plugins.credentials.impl.*;
-
-      #{credentials_for_id_groovy(new_resource.id, 'credentials')}
-
-      if(credentials == null) {
-        return null
-      }
-
-      current_credentials = [
-        id:credentials.id,
-        description:credentials.description,
-        username:credentials.username
-      ]
-
-      current_credentials['password'] = credentials.password.plainText
-
-      builder = new groovy.json.JsonBuilder(current_credentials)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_credentials = JSON.parse(json, symbolize_names: true)
-    @current_credentials = convert_blank_values_to_nil(@current_credentials)
-  end
+  include Jenkins::PasswordCredentialsHelpers
 
   def correct_config?
     wanted_credentials = {

--- a/resources/private_key_credentials.rb
+++ b/resources/private_key_credentials.rb
@@ -6,6 +6,8 @@ unified_mode true
 resource_name :jenkins_private_key_credentials
 provides :jenkins_private_key_credentials
 
+include Jenkins::PrivateKeyCredentialsHelpers
+
 property :id, String, required: true
 property :username, String, name_property: true
 property :private_key, [String, OpenSSL::PKey::RSA, OpenSSL::PKey::EC], required: true, sensitive: true
@@ -19,8 +21,8 @@ def initialize(name, run_context = nil)
   @sensitive = true
 end
 
-load_current_value do
-  current_creds = current_credentials_from_jenkins
+load_current_value do |new_resource|
+  current_creds = current_credentials_from_jenkins(new_resource)
 
   if current_creds
     id current_creds[:id]
@@ -107,70 +109,7 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-  include Jenkins::CredentialsHelpers
-
-  #
-  # Determine whether a key is an ECDSA key.
-  #
-  def ecdsa_key?(key)
-    key.include?('BEGIN EC PRIVATE KEY')
-  end
-
-  #
-  # Private key in PEM format
-  #
-  def pem_private_key
-    if new_resource.private_key.is_a?(OpenSSL::PKey::RSA) || new_resource.private_key.is_a?(OpenSSL::PKey::EC)
-      new_resource.private_key.to_pem
-    elsif ecdsa_key?(new_resource.private_key)
-      OpenSSL::PKey::EC.new(new_resource.private_key).to_pem
-    else
-      OpenSSL::PKey::RSA.new(new_resource.private_key).to_pem
-    end
-  end
-
-  def current_credentials_from_jenkins
-    return @current_credentials if @current_credentials
-
-    Chef::Log.debug "Load #{new_resource} credentials information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import com.cloudbees.jenkins.plugins.sshcredentials.impl.*;
-
-      #{credentials_for_id_groovy(new_resource.id, 'credentials')}
-
-      if(credentials == null) {
-        return null
-      }
-
-      current_credentials = [
-        id:credentials.id,
-        description:credentials.description,
-        username:credentials.username
-      ]
-
-      current_credentials['private_key'] = credentials.privateKey
-      current_credentials['passphrase'] = credentials.passphrase && credentials.passphrase.plainText
-
-      builder = new groovy.json.JsonBuilder(current_credentials)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_credentials = JSON.parse(json, symbolize_names: true)
-    @current_credentials = convert_blank_values_to_nil(@current_credentials)
-
-    # Normalize the private key
-    if @current_credentials && @current_credentials[:private_key]
-      cc = @current_credentials[:private_key]
-      cc = @current_credentials[:private_key].to_pem unless cc.is_a?(String)
-      @current_credentials[:private_key] = ecdsa_key?(cc) ? OpenSSL::PKey::EC.new(cc) : OpenSSL::PKey::RSA.new(cc)
-    end
-
-    @current_credentials
-  end
+  include Jenkins::PrivateKeyCredentialsHelpers
 
   def correct_config?
     wanted_credentials = {

--- a/resources/proxy.rb
+++ b/resources/proxy.rb
@@ -5,13 +5,15 @@ unified_mode true
 resource_name :jenkins_proxy
 provides :jenkins_proxy
 
+include Jenkins::ProxyHelpers
+
 property :proxy, String, name_property: true
 property :noproxy, Array, default: []
 property :username, String
 property :password, String
 
-load_current_value do |_new_resource|
-  current_proxy = current_proxy_from_jenkins
+load_current_value do |new_resource|
+  current_proxy = current_proxy_from_jenkins(new_resource)
 
   if current_proxy
     proxy current_proxy[:proxy]
@@ -76,47 +78,5 @@ action :remove do
 end
 
 action_class do
-  include Jenkins::Helper
-
-  #
-  # Loads the local proxy into a hash
-  #
-  def current_proxy_from_jenkins
-    return @current_proxy if @current_proxy
-
-    Chef::Log.debug "Load #{new_resource} proxy information"
-
-    json = executor.groovy <<-EOH.gsub(/^ {6}/, '')
-      import java.util.Collections
-      import java.util.List
-
-      import jenkins.model.Jenkins
-      def instance = Jenkins.getInstance()
-
-      def pc = instance.proxy
-      if (pc == null) {
-        return null
-      }
-
-      def no_proxy = pc.noProxyHost
-      if (no_proxy != null) {
-        no_proxy = no_proxy.tokenize('[ \\t\\n,|]+')
-      } else {
-        no_proxy = Collections.emptyList()
-      }
-
-      def builder = new groovy.json.JsonBuilder()
-      builder {
-        proxy pc.name + ':' + pc.port.toString()
-        noproxy no_proxy
-      }
-
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_proxy = JSON.parse(json, symbolize_names: true)
-    @current_proxy
-  end
+  include Jenkins::ProxyHelpers
 end

--- a/resources/secret_text_credentials.rb
+++ b/resources/secret_text_credentials.rb
@@ -5,6 +5,8 @@ unified_mode true
 resource_name :jenkins_secret_text_credentials
 provides :jenkins_secret_text_credentials
 
+include Jenkins::SecretTextCredentialsHelpers
+
 property :id, String, name_property: true
 property :secret, String, required: true, sensitive: true
 property :description, String,
@@ -16,8 +18,8 @@ def initialize(name, run_context = nil)
   @sensitive = true
 end
 
-load_current_value do
-  current_creds = current_credentials_from_jenkins
+load_current_value do |new_resource|
+  current_creds = current_credentials_from_jenkins(new_resource)
 
   if current_creds
     id current_creds[:id]
@@ -98,40 +100,7 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-  include Jenkins::CredentialsHelpers
-
-  def current_credentials_from_jenkins
-    return @current_credentials if @current_credentials
-
-    Chef::Log.debug "Load #{new_resource} credentials information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import org.jenkinsci.plugins.plaincredentials.impl.*;
-
-      #{credentials_for_id_groovy(new_resource.id, 'credentials')}
-
-      if(credentials == null) {
-        return null
-      }
-
-      current_credentials = [
-        id:credentials.id,
-        description:credentials.description,
-        secret:credentials.secret
-      ]
-
-      current_credentials['secret'] = credentials.secret.plainText
-
-      builder = new groovy.json.JsonBuilder(current_credentials)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_credentials = JSON.parse(json, symbolize_names: true)
-    @current_credentials = convert_blank_values_to_nil(@current_credentials)
-  end
+  include Jenkins::SecretTextCredentialsHelpers
 
   def correct_config?
     wanted_credentials = {

--- a/resources/ssh_agent.rb
+++ b/resources/ssh_agent.rb
@@ -7,6 +7,7 @@ provides :jenkins_ssh_agent
 provides :jenkins_ssh_slave # Backwards compatibility alias
 
 use '_partial/_agent'
+include Jenkins::SshAgentHelpers
 
 # SSH-specific properties
 property :host, String
@@ -18,8 +19,8 @@ property :launch_timeout, Integer
 property :ssh_retries, Integer
 property :ssh_wait_retries, Integer
 
-load_current_value do
-  current_slave_data = current_slave_from_jenkins
+load_current_value do |new_resource|
+  current_slave_data = current_slave_from_jenkins(new_resource)
 
   if current_slave_data
     slave_name current_slave_data[:name]
@@ -89,7 +90,7 @@ action :offline do
 end
 
 action_class do
-  include Jenkins::Helper
+  include Jenkins::SshAgentHelpers
 
   def exists?
     !@exists.nil? && @exists
@@ -199,76 +200,6 @@ action_class do
 
   def parsed_credentials
     new_resource.credentials.to_s
-  end
-
-  def attribute_to_property_map
-    {
-      host: 'launcher.host',
-      port: 'launcher.port',
-      credentials: 'launcher.credentialsId',
-    }
-  end
-
-  def current_slave_from_jenkins
-    return @current_slave if @current_slave
-
-    Chef::Log.debug "Load #{new_resource} agent information"
-
-    launcher_attributes = []
-    attribute_to_property_map.each_pair do |resource_attribute, groovy_property|
-      launcher_attributes << "current_slave['#{resource_attribute}'] = #{groovy_property}"
-    end
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import hudson.model.*
-      import hudson.slaves.*
-      import jenkins.model.*
-      import jenkins.slaves.*
-
-      slave = Jenkins.instance.getNode('#{new_resource.slave_name}') as Slave
-
-      if(slave == null) {
-        return null
-      }
-
-      def slave_environment = null
-      slave_env_vars = slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars
-      if (slave_env_vars)
-        slave_environment = new java.util.HashMap<String,String>(slave_env_vars)
-
-      current_slave = [
-        name:slave.name,
-        description:slave.nodeDescription,
-        remote_fs:slave.remoteFS,
-        executors:slave.numExecutors.toInteger(),
-        usage_mode:slave.mode.toString().toLowerCase(),
-        labels:slave.labelString.split().sort(),
-        environment:slave_environment,
-        connected:(slave.computer.connectTime > 0),
-        online:slave.computer.online
-      ]
-
-      if (slave.retentionStrategy instanceof RetentionStrategy.Always) {
-        current_slave['availability'] = 'always'
-      } else if (slave.retentionStrategy instanceof RetentionStrategy.Demand) {
-        current_slave['availability'] = 'demand'
-        retention = slave.retentionStrategy as RetentionStrategy.Demand
-        current_slave['in_demand_delay'] = retention.inDemandDelay
-        current_slave['idle_delay'] = retention.idleDelay
-      } else {
-        current_slave['availability'] = null
-      }
-
-      #{launcher_attributes.join("\n")}
-
-      builder = new groovy.json.JsonBuilder(current_slave)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_slave = JSON.parse(json, symbolize_names: true)
-    @current_slave = convert_blank_values_to_nil(@current_slave)
   end
 
   def correct_config?

--- a/resources/view.rb
+++ b/resources/view.rb
@@ -3,11 +3,13 @@ unified_mode true
 resource_name :jenkins_view
 provides :jenkins_view
 
+include Jenkins::ViewHelpers
+
 property :jobs, Array, default: []
 property :code, String, default: ''
 
-load_current_value do |_new_resource|
-  current_view = current_view_from_jenkins
+load_current_value do |new_resource|
+  current_view = current_view_from_jenkins(new_resource)
 
   if current_view && !current_view.empty?
     jobs current_view[:jobs] || []
@@ -86,47 +88,5 @@ action :delete do
 end
 
 action_class do
-  include Jenkins::Helper
-
-  #
-  # The view in a hash format
-  #
-  # @return [Hash]
-  #   Empty hash if the job does not exist, or a hash of important information
-  #   if it does
-  #
-  def current_view_from_jenkins
-    return @current_view if @current_view
-
-    Chef::Log.debug "Load #{new_resource} view information"
-
-    get_view_as_json =
-      <<-GROOVY
-        import hudson.model.*
-        import jenkins.model.*
-        view_name = '#{new_resource.name}'
-        jenkins = Jenkins.instance
-
-        def view_variables = new groovy.json.JsonBuilder()
-        view_variables {}
-
-        // Output view as JSON, easily parse-able by ruby
-        view = jenkins.getView(view_name)
-        if (view) {
-          view_variables {
-            name view_name
-            jobs view.getItems().collect { it.name }
-          }
-        }
-
-        println view_variables.toString()
-      GROOVY
-
-    response = executor.groovy!(get_view_as_json)
-    return if response.nil?
-
-    Chef::Log.debug "Parse #{new_resource} as JSON"
-    @current_view = JSON.parse(response, object_class: Mash)
-    @current_view
-  end
+  include Jenkins::ViewHelpers
 end

--- a/resources/windows_agent.rb
+++ b/resources/windows_agent.rb
@@ -7,6 +7,7 @@ provides :jenkins_windows_agent
 provides :jenkins_windows_slave # Backwards compatibility alias
 
 use '_partial/_agent'
+include Jenkins::AgentHelpers
 
 property :remote_fs, String, default: 'C:\\Jenkins'
 property :user, String, default: 'Administrator'
@@ -14,8 +15,8 @@ property :user, String, default: 'Administrator'
 # Windows-specific properties
 property :password, String, sensitive: true
 
-load_current_value do
-  current_slave_data = current_slave_from_jenkins
+load_current_value do |new_resource|
+  current_slave_data = current_slave_from_jenkins(new_resource)
 
   if current_slave_data
     slave_name current_slave_data[:name]
@@ -84,7 +85,7 @@ action :offline do
 end
 
 action_class do
-  include Jenkins::Helper
+  include Jenkins::AgentHelpers
 
   def exists?
     !@exists.nil? && @exists
@@ -178,61 +179,6 @@ action_class do
     else
       Chef::Log.debug("#{new_resource} does not exist - skipping")
     end
-  end
-
-  def current_slave_from_jenkins
-    return @current_slave if @current_slave
-
-    Chef::Log.debug "Load #{new_resource} agent information"
-
-    json = executor.groovy! <<-EOH.gsub(/^ {6}/, '')
-      import hudson.model.*
-      import hudson.slaves.*
-      import jenkins.model.*
-      import jenkins.slaves.*
-
-      slave = Jenkins.instance.getNode('#{new_resource.slave_name}') as Slave
-
-      if(slave == null) {
-        return null
-      }
-
-      def slave_environment = null
-      slave_env_vars = slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars
-      if (slave_env_vars)
-        slave_environment = new java.util.HashMap<String,String>(slave_env_vars)
-
-      current_slave = [
-        name:slave.name,
-        description:slave.nodeDescription,
-        remote_fs:slave.remoteFS,
-        executors:slave.numExecutors.toInteger(),
-        usage_mode:slave.mode.toString().toLowerCase(),
-        labels:slave.labelString.split().sort(),
-        environment:slave_environment,
-        connected:(slave.computer.connectTime > 0),
-        online:slave.computer.online
-      ]
-
-      if (slave.retentionStrategy instanceof RetentionStrategy.Always) {
-        current_slave['availability'] = 'always'
-      } else if (slave.retentionStrategy instanceof RetentionStrategy.Demand) {
-        current_slave['availability'] = 'demand'
-        retention = slave.retentionStrategy as RetentionStrategy.Demand
-        current_slave['in_demand_delay'] = retention.inDemandDelay
-        current_slave['idle_delay'] = retention.idleDelay
-      } else {
-        current_slave['availability'] = null
-      }
-
-      builder = new groovy.json.JsonBuilder(current_slave)
-      println(builder)
-    EOH
-
-    return if json.nil? || json.empty?
-
-    @current_slave = JSON.parse(json, symbolize_names: true)
-    @current_slave = convert_blank_values_to_nil(@current_slave)
   end
 
   def correct_config?

--- a/spec/resources/current_value_helpers_spec.rb
+++ b/spec/resources/current_value_helpers_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'custom resource current value helpers' do
+  platform 'ubuntu'
+  step_into :jenkins_agent
+  step_into :jenkins_file_credentials
+  step_into :jenkins_githubapp_credentials
+  step_into :jenkins_jnlp_agent
+  step_into :jenkins_password_credentials
+  step_into :jenkins_proxy
+  step_into :jenkins_secret_text_credentials
+  step_into :jenkins_ssh_agent
+  step_into :jenkins_view
+  step_into :jenkins_windows_agent
+
+  let(:executor) { instance_double(Jenkins::Executor) }
+
+  before do
+    allow_any_instance_of(Jenkins::Helper).to receive(:executor)
+      .and_return(executor)
+    allow(executor).to receive(:groovy).and_return(nil)
+    allow(executor).to receive(:groovy!).and_return(nil)
+    allow(executor).to receive(:execute!).and_return(true)
+  end
+
+  context 'with credential resources' do
+    recipe do
+      jenkins_password_credentials 'user' do
+        id 'password-id'
+        password 'secret'
+      end
+
+      jenkins_file_credentials 'file.txt' do
+        id 'file-id'
+        data 'content'
+      end
+
+      jenkins_secret_text_credentials 'secret-id' do
+        secret 'secret'
+      end
+
+      jenkins_githubapp_credentials '12345' do
+        id 'github-app-id'
+        owner 'sous-chefs'
+        private_key_pkcs8_pem 'private-key'
+      end
+    end
+
+    it 'loads current credentials without action_class visibility errors' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
+
+  context 'with agent resources' do
+    recipe do
+      jenkins_agent 'agent'
+
+      jenkins_jnlp_agent 'jnlp-agent'
+
+      jenkins_ssh_agent 'ssh-agent' do
+        host '127.0.0.1'
+      end
+
+      jenkins_windows_agent 'windows-agent'
+    end
+
+    it 'loads current agents without action_class visibility errors' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
+
+  context 'with proxy and view resources' do
+    recipe do
+      jenkins_proxy 'proxy.example.test:8080'
+
+      jenkins_view 'main' do
+        jobs %w(build test)
+      end
+    end
+
+    it 'loads current state without action_class visibility errors' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
+end

--- a/spec/resources/private_key_credentials_spec.rb
+++ b/spec/resources/private_key_credentials_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'jenkins_private_key_credentials custom resource' do
+  PRIVATE_KEY = <<~KEY.freeze
+    -----BEGIN PRIVATE KEY-----
+    MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEA/Fu0qiWDCRmc1ood
+    oPH8u9NL16SZUkST0cHVqLjZ6eTAcfvhDicDWOn7+tmnnu5Qu69/hcuHoIUwuoIh
+    o5gMTwIDAQABAkBOnULqvkTT0ObK7rvMJ5ZT7L7zrpMUzcg+z+N/bBZ2he4QkWVU
+    /JBwwR76BKqJIfsNcv2yoBjKoz1C1dvHasoBAiEA/2pyskU8qui2zh5B6W1WmG4n
+    LQl8Y+i9fa5CpbywG50CIQD873ene3Ma4SIhFR+1/uCyFy/oFTbrzxpCOCVrfBcR
+    2wIgbu6cwjCwGMraGsupdOi4I5w0B6uHCx2ar2twJuu80UECIQDB7bkIKJawXT0V
+    sGSH3cvZv/1zLBDX7ApuCy5lotbtUQIgGEFtNp5jD+ahliwiJPk3WxBKHueMtXGt
+    oLHZQLvnj74=
+    -----END PRIVATE KEY-----
+  KEY
+
+  platform 'ubuntu'
+  step_into :jenkins_private_key_credentials
+
+  let(:executor) { instance_double(Jenkins::Executor) }
+
+  before do
+    allow_any_instance_of(Jenkins::Helper).to receive(:executor)
+      .and_return(executor)
+    allow(executor).to receive(:groovy!).and_return(nil, '')
+  end
+
+  context 'when creating private key credentials' do
+    recipe do
+      jenkins_private_key_credentials 'jenkins' do
+        id '78d4bc59-4345-4cd7-aff6-c86bc539eac4'
+        description 'Test user'
+        private_key PRIVATE_KEY
+      end
+    end
+
+    it 'loads current credentials before converging' do
+      expect { chef_run }.not_to raise_error
+      expect(executor).to have_received(:groovy!).at_least(:once)
+    end
+  end
+end

--- a/spec/resources/view_spec.rb
+++ b/spec/resources/view_spec.rb
@@ -3,15 +3,13 @@ require 'spec_helper'
 describe 'jenkins_view custom resource' do
   platform 'ubuntu'
   step_into :jenkins_view
+  let(:executor) { instance_double(Jenkins::Executor) }
 
   before do
     # Mock the executor to avoid actual Jenkins CLI calls
     allow_any_instance_of(Jenkins::Helper).to receive(:executor)
-      .and_return(double('executor').as_null_object)
-
-    # Mock the current_view_from_jenkins method
-    allow_any_instance_of(Object).to receive(:current_view_from_jenkins)
-      .and_return({ jobs: [] })
+      .and_return(executor)
+    allow(executor).to receive(:groovy!).and_return('{"jobs":[]}', nil)
   end
 
   context 'when creating a view' do


### PR DESCRIPTION
## Summary
- Fix custom resources whose load_current_value blocks called helper methods only available in action_class
- Move current-state lookup helpers into shared library modules for credentials, agents, proxy, and view resources
- Add regression specs for the affected current value helper paths

Fixes #850

## Verification
- cookstyle
- markdownlint
- chef exec rspec --format documentation
- yamllint